### PR TITLE
QH - DSPDC-1028 - Bumping sbtPluginsVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 //import _root_.io.circe.Json
-import org.broadinstitute.monster.sbt.model.JadeIdentifier
 
 lazy val `hca-ingest` = project
   .in(file("."))
@@ -10,10 +9,6 @@ lazy val `hca-schema` = project
   .in(file("schema"))
   .enablePlugins(MonsterJadeDatasetPlugin)
   .settings(
-    jadeDatasetName := JadeIdentifier
-      .fromString("broad_dsp_hca")
-      .fold(sys.error, identity),
-    jadeDatasetDescription := "Mirror of HCA archive, maintained by Broad's Data Sciences Platform",
     jadeTablePackage := "org.broadinstitute.monster.hca.jadeschema.table",
     jadeStructPackage := "org.broadinstitute.monster.hca.jadeschema.struct"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val sbtPluginsVersion = "0.20.0"
+val sbtPluginsVersion = "0.23.0"
 
 val patternBase =
   "org/broadinstitute/monster/[module](_[scalaVersion])(_[sbtVersion])/[revision]"


### PR DESCRIPTION
Updating the sbtPluginsVersion to match the most recent monster-sbt-plugins release.
Updating build.sbt to reflect Raaid's downstream changes in DSPDC-1067.
This project does not yet have pipeline tests to report on.