### PR TITLE
Sw dspdc 1082 unit test for metadata transformation

### DIFF
--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -7,17 +7,17 @@ import org.scalatest.matchers.should.Matchers
 class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
   behavior of "HcaPipelineBuilder"
 
-  it should "transform metadata" in {
+  it should "transform basic metadata" in {
     val exampleFileContent = JsonParser.parseEncodedJson("""{"beep": "boop"}""")
     val actualOutput = HcaPipelineBuilder.transformMetadata(
       entityType = "entity_type",
-      fileName = "id_version.json",
+      fileName = "entityId_version.json",
       metadata = exampleFileContent
-    ) // TODO read hca planning doc to get more realistic filename
+    )
     val expectedOutput = JsonParser.parseEncodedJson(
       json = """
                | {
-               |   "entity_type_id": "id",
+               |   "entity_type_id": "entityId",
                |   "version": "version",
                |   "content": "{\"beep\":\"boop\"}"
                | }

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.monster.hca
+
+import org.broadinstitute.monster.common.msg.JsonParser
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
+  behavior of "HcaPipelineBuilder"
+
+  it should "transform metadata" in {
+    val exampleFileContent = JsonParser.parseEncodedJson("""{"beep": "boop"}""")
+    val actualOutput = HcaPipelineBuilder.transformMetadata(
+      entityType = "entity_type",
+      fileName = "id_version.json",
+      metadata = exampleFileContent
+    ) // TODO read hca planning doc to get more realistic filename
+    val expectedOutput = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |   "entity_type_id": "id",
+               |   "version": "version",
+               |   "content": "{\"beep\":\"boop\"}"
+               | }
+               |""".stripMargin
+    )
+
+    actualOutput shouldBe expectedOutput
+  }
+}


### PR DESCRIPTION
Writing a unit test for the metadataTransformation method ([Jira Ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1082)).

I had been debating writing a test for the processMetadata method too, but wasn't sure if it was worth the effort of setting up the file test input/output files and temporary directory. If anyone feels like we should have it, I'd be happy to add it in. 