### PR TITLE
Sw dspdc 1077 process file metadata

### DIFF
--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -34,7 +34,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
   // format is: metadata/{entity_type}/{entity_id}_{version}.json,
   // but filename returns just {entity_id}_{version}.json, so that is what we deal with.
   val metadataPattern: Regex = "([^_]+)_(.+).json".r
-  // format is: {dir_path}{file_id}_{file_version}_{file_name},
+  // format is: {dir_path}/{file_id}_{file_version}_{file_name},
   // but the dir_path seems to be optional
   val fileDataPattern: Regex = "(.*\\/)?([^_^\\/]+)_([^_]+)_(.+)".r
 
@@ -145,7 +145,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         Str("content") -> Str(encode(metadata).getOrElse("")),
         Str("file_id") -> Str(fileId),
         Str("file_version") -> Str(fileVersion),
-        Str("content_hash") -> Str(checksum.getOrElse(""))
+        Str("checksum") -> Str(checksum.getOrElse(""))
       )
     )
   }

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -134,10 +134,8 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     * @return a Msg object in the desired output format
     */
   def transformFileMetadata(entityType: String, fileName: String, metadata: Msg): Msg = {
-    val coreFileMetadata = metadata.read[Msg]("file_core")
-    val checksum = coreFileMetadata.tryRead[String]("checksum")
-    val dataFileName = coreFileMetadata.read[String]("file_name")
     val (entityId, entityVersion) = getEntityIdAndVersion(fileName: String)
+    val dataFileName = metadata.read[Msg]("file_core").read[String]("file_name")
     val (fileId, fileVersion) = getFileIdAndVersion(dataFileName)
     // put values in the form we want
     Obj(
@@ -145,9 +143,8 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         Str(s"${entityType}_id") -> Str(entityId),
         Str("version") -> Str(entityVersion),
         Str("content") -> Str(encode(metadata).getOrElse("")),
-        Str("file_id") -> Str(fileId),
-        Str("file_version") -> Str(fileVersion),
-        Str("checksum") -> Str(checksum.getOrElse(""))
+        Str("source_file_id") -> Str(fileId),
+        Str("source_file_version") -> Str(fileVersion)
       )
     )
   }

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -117,7 +117,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
       mutable.LinkedHashMap[Msg, Msg](
         Str(s"${entityType}_id") -> Str(entityId),
         Str("version") -> Str(entityVersion),
-        Str("content") -> Str(encode(metadata).getOrElse(""))
+        Str("content") -> Str(encode(metadata))
       )
     )
   }
@@ -142,7 +142,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
       mutable.LinkedHashMap[Msg, Msg](
         Str(s"${entityType}_id") -> Str(entityId),
         Str("version") -> Str(entityVersion),
-        Str("content") -> Str(encode(metadata).getOrElse("")),
+        Str("content") -> Str(encode(metadata)),
         Str("content_hash") -> Str(contentHash),
         Str("source_file_id") -> Str(fileId),
         Str("source_file_version") -> Str(fileVersion)
@@ -188,12 +188,9 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     (fileId, fileVersion)
   }
 
-  def encode(msg: Msg): Option[String] =
-    if (msg.obj.isEmpty) {
-      None
-    } else {
-      Some(upack.transform(msg, StringRenderer()).toString)
-    }
+  /** Convert a Msg to a JSON string. */
+  def encode(msg: Msg): String =
+    upack.transform(msg, StringRenderer()).toString
 
   /**
     * Read, transform, and write a given entity type.

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -143,7 +143,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         Str(s"${entityType}_id") -> Str(entityId),
         Str("version") -> Str(entityVersion),
         Str("content") -> Str(encode(metadata)),
-        Str("content_hash") -> Str(contentHash),
+        Str("crc32c") -> Str(contentHash),
         Str("source_file_id") -> Str(fileId),
         Str("source_file_version") -> Str(fileVersion)
       )

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -33,10 +33,10 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                | {
                |    "file_core": {
                |        "file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
-               |        "format": "csv"
+               |        "format": "csv",
+               |        "file_crc32c": "54321zyx"
                |    },
-               |    "schema_type": "file",
-               |    "checksum": null
+               |    "schema_type": "file"
                | }
                |""".stripMargin
     )
@@ -52,7 +52,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           | {
           |   "some_file_entity_type_id": "entity-id",
           |   "version": "entity-version",
-          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\"},\"schema_type\":\"file\",\"checksum\":null}",
+          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_crc32c\":\"54321zyx\"},\"schema_type\":\"file\"}",
+          |   "content_hash": "54321zyx",
           |   "source_file_id": "some-id",
           |   "source_file_version": "some-version.numbers123"
           | }
@@ -68,7 +69,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                | {
                |    "file_core": {
                |        "file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
-               |        "format": "json"
+               |        "format": "json",
+               |        "file_crc32c": "abcd1234"
                |    }
                | }
                |""".stripMargin
@@ -84,7 +86,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           | {
           |   "some_type_id": "123",
           |   "version": "456",
-          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\"}}",
+          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_crc32c\":\"abcd1234\"}}",
+          |   "content_hash": "abcd1234",
           |   "source_file_id": "file-id",
           |   "source_file_version": "file-version"
           | }

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -72,7 +72,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "some_file_entity_type_id": "entity-id",
           |   "version": "entity-version",
           |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_crc32c\":\"54321zyx\"},\"schema_type\":\"file\"}",
-          |   "content_hash": "54321zyx",
+          |   "crc32c": "54321zyx",
           |   "source_file_id": "some-id",
           |   "source_file_version": "some-version.numbers123"
           | }
@@ -106,7 +106,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "some_type_id": "123",
           |   "version": "456",
           |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_crc32c\":\"abcd1234\"}}",
-          |   "content_hash": "abcd1234",
+          |   "crc32c": "abcd1234",
           |   "source_file_id": "file-id",
           |   "source_file_version": "file-version"
           | }

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -27,6 +27,25 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
     actualOutput shouldBe expectedOutput
   }
 
+  it should "transform an empty metadata file" in {
+    val actualOutput = HcaPipelineBuilder.transformMetadata(
+      entityType = "entity_type",
+      fileName = "id_version.json",
+      metadata = JsonParser.parseEncodedJson("{}")
+    )
+    val expectedOutput = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |   "entity_type_id": "id",
+               |   "version": "version",
+               |   "content": "{}"
+               | }
+               |""".stripMargin
+    )
+
+    actualOutput shouldBe expectedOutput
+  }
+
   it should "transform file metadata with no directory in the filename" in {
     val exampleMetadataContent = JsonParser.parseEncodedJson(
       json = """

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -26,4 +26,41 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
 
     actualOutput shouldBe expectedOutput
   }
+
+  it should "transform basic file metadata" in {
+    val exampleMetadataContent = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |   "describedBy": "a url",
+               |    "file_core": {
+               |        "file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
+               |        "format": "csv"
+               |    },
+               |    "schema_type": "file"
+               | }
+               |""".stripMargin
+    )
+    val actualOutput = HcaPipelineBuilder.transformFileMetadata(
+      entityType = "some_file_entity_type",
+      fileName = "entity-id_entity-version.json",
+      metadata = exampleMetadataContent
+    )
+    val expectedOutput = JsonParser.parseEncodedJson(
+      json =
+        """
+          | {
+          |   "some_file_entity_type_id": "entity-id",
+          |   "version": "entity-version",
+          |   "content": "{\"describedBy\":\"a url\",\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\"},\"schema_type\":\"file\"}",
+          |   "file_id": "some-id",
+          |   "file_version": "some-version.numbers123",
+          |   "content_hash": ""
+          | }
+          |""".stripMargin
+    )
+
+    actualOutput shouldBe expectedOutput
+  }
+
+  it should "transform file metadata with a checksum" in {}
 }

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -35,7 +35,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                |        "file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
                |        "format": "csv"
                |    },
-               |    "schema_type": "file"
+               |    "schema_type": "file",
+               |    "checksum": null
                | }
                |""".stripMargin
     )
@@ -51,7 +52,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           | {
           |   "some_file_entity_type_id": "entity-id",
           |   "version": "entity-version",
-          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\"},\"schema_type\":\"file\"}",
+          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\"},\"schema_type\":\"file\",\"checksum\":null}",
           |   "file_id": "some-id",
           |   "file_version": "some-version.numbers123",
           |   "checksum": ""

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -27,7 +27,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
     actualOutput shouldBe expectedOutput
   }
 
-  it should "transform basic file metadata" in {
+  it should "transform file metadata with no directory in the filename" in {
     val exampleMetadataContent = JsonParser.parseEncodedJson(
       json = """
                | {
@@ -40,7 +40,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                | }
                |""".stripMargin
     )
-    // TODO does this fail when checksum is "null"?
+
     val actualOutput = HcaPipelineBuilder.transformFileMetadata(
       entityType = "some_file_entity_type",
       fileName = "entity-id_entity-version.json",
@@ -53,9 +53,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "some_file_entity_type_id": "entity-id",
           |   "version": "entity-version",
           |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\"},\"schema_type\":\"file\",\"checksum\":null}",
-          |   "file_id": "some-id",
-          |   "file_version": "some-version.numbers123",
-          |   "checksum": ""
+          |   "source_file_id": "some-id",
+          |   "source_file_version": "some-version.numbers123"
           | }
           |""".stripMargin
     )
@@ -63,14 +62,13 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
     actualOutput shouldBe expectedOutput
   }
 
-  it should "transform file metadata with a directory and checksum" in {
+  it should "transform file metadata with a directory in the filename" in {
     val exampleMetadataContent = JsonParser.parseEncodedJson(
       json = """
                | {
                |    "file_core": {
                |        "file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
-               |        "format": "json",
-               |        "checksum": "abcdefg"
+               |        "format": "json"
                |    }
                | }
                |""".stripMargin
@@ -86,10 +84,9 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           | {
           |   "some_type_id": "123",
           |   "version": "456",
-          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"checksum\":\"abcdefg\"}}",
-          |   "file_id": "file-id",
-          |   "file_version": "file-version",
-          |   "checksum": "abcdefg"
+          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\"}}",
+          |   "source_file_id": "file-id",
+          |   "source_file_version": "file-version"
           | }
           |""".stripMargin
     )


### PR DESCRIPTION
Transforming the file metadata: 
- file_id and file_version are parsed out of the name of the data file
- the entity id and version are parsed out of the name of the metadata file (the same way they are for the rest of the metadata)
- the checksum value is read from the json 