### PR TITLE
Sw dspdc 1078 generate file ingest requests

### DIFF
--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -18,14 +18,12 @@ import scala.util.matching.Regex
 object HcaPipelineBuilder extends PipelineBuilder[Args] {
 
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
-    // transform metadata
     val allMetadataEntities =
       metadataEntities.map(_ -> false) ++ fileMetadataEntities.map(_ -> true)
     allMetadataEntities.foreach {
       case (entityType, isFileMetadata) =>
         processMetadata(ctx, args.inputPrefix, args.outputPrefix, entityType, isFileMetadata)
     }
-    // generateFileIngestRequests
     ()
   }
 

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -151,6 +151,28 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
   }
 
   /**
+    * Extract the necessary info from file metadata and put it into a form that
+    * can be used to generate bulk file ingest requests.
+    * @param metadata the content of the metadata file in Msg format
+    * @param inputPrefix the root directory containing input files
+    * @return a Msg object in the desired output format
+    */
+  def generateFileIngestRequest(metadata: Msg, inputPrefix: String): Msg = {
+    val contentHash = metadata.read[String]("file_core", "file_crc32c")
+    val dataFileName = metadata.read[String]("file_core", "file_name")
+    val sourcePath = s"$inputPrefix/data/$dataFileName"
+    val targetPath = s"/$dataFileName"
+
+    Obj(
+      mutable.LinkedHashMap[Msg, Msg](
+        Str("sourcePath") -> Str(sourcePath),
+        Str("targetPath") -> Str(targetPath),
+        Str("crc32c") -> Str(contentHash)
+      )
+    )
+  }
+
+  /**
     * Extract the entity id and entity version from the name of a metadata file.
     *
     * @param fileName the raw filename of the metadata file

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -249,7 +249,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
       StorageIO.writeJsonLists(
         fileIngestRequests,
         entityType,
-        s"${outputPrefix}/data/${entityType}"
+        s"${outputPrefix}/data-transfer-requests/${entityType}"
       )
     }
     // then write to storage

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -165,8 +165,8 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
 
     Obj(
       mutable.LinkedHashMap[Msg, Msg](
-        Str("sourcePath") -> Str(sourcePath),
-        Str("targetPath") -> Str(targetPath),
+        Str("source_path") -> Str(sourcePath),
+        Str("target_path") -> Str(targetPath),
         Str("crc32c") -> Str(contentHash)
       )
     )

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -74,7 +74,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_crc32c\":\"54321zyx\"},\"schema_type\":\"file\"}",
           |   "crc32c": "54321zyx",
           |   "source_file_id": "some-id",
-          |   "source_file_version": "some-version.numbers123"
+          |   "source_file_version": "some-version.numbers123",
+          |   "data_file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv"
           | }
           |""".stripMargin
     )
@@ -108,7 +109,8 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_crc32c\":\"abcd1234\"}}",
           |   "crc32c": "abcd1234",
           |   "source_file_id": "file-id",
-          |   "source_file_version": "file-version"
+          |   "source_file_version": "file-version",
+          |   "data_file_name": "a-directory/sub_directory/file-id_file-version_filename.json"
           | }
           |""".stripMargin
     )
@@ -117,28 +119,33 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "correctly generate file ingest requests" in {
-    val exampleFileMetadata = JsonParser.parseEncodedJson(
-      json = """
-               | {
-               |    "file_core": {
-               |        "file_name": "file-id_version_filename.json",
-               |        "file_crc32c": "abcd1234"
-               |    }
-               | }
-               |""".stripMargin
+    val exampleProcessedFileMetadata = JsonParser.parseEncodedJson(
+      json =
+        """
+          | {
+          |   "some_type_id": "123",
+          |   "version": "456",
+          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_crc32c\":\"abcd1234\"}}",
+          |   "crc32c": "abcd1234",
+          |   "source_file_id": "file-id",
+          |   "source_file_version": "file-version",
+          |   "data_file_name": "a-directory/sub_directory/file-id_file-version_filename.json"
+          | }
+          |""".stripMargin
     )
     val actualOutput = HcaPipelineBuilder.generateFileIngestRequest(
-      metadata = exampleFileMetadata,
+      metadata = exampleProcessedFileMetadata,
       inputPrefix = "some/local/directory"
     )
     val expectedOutput = JsonParser.parseEncodedJson(
-      json = """
-               | {
-               |   "source_path": "some/local/directory/data/file-id_version_filename.json",
-               |   "target_path": "/file-id_version_filename.json",
-               |   "crc32c": "abcd1234"
-               | }
-               |""".stripMargin
+      json =
+        """
+          | {
+          |   "source_path": "some/local/directory/data/a-directory/sub_directory/file-id_file-version_filename.json",
+          |   "target_path": "/a-directory/sub_directory/file-id_file-version_filename.json",
+          |   "crc32c": "abcd1234"
+          | }
+          |""".stripMargin
     )
 
     actualOutput shouldBe expectedOutput

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -115,4 +115,32 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
 
     actualOutput shouldBe expectedOutput
   }
+
+  it should "correctly generate file ingest requests" in {
+    val exampleFileMetadata = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |    "file_core": {
+               |        "file_name": "file-id_version_filename.json",
+               |        "file_crc32c": "abcd1234"
+               |    }
+               | }
+               |""".stripMargin
+    )
+    val actualOutput = HcaPipelineBuilder.generateFileIngestRequest(
+      metadata = exampleFileMetadata,
+      inputPrefix = "some/local/directory"
+    )
+    val expectedOutput = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |   "source_path": "some/local/directory/data/file-id_version_filename.json",
+               |   "target_path": "/file-id_version_filename.json",
+               |   "crc32c": "abcd1234"
+               | }
+               |""".stripMargin
+    )
+
+    actualOutput shouldBe expectedOutput
+  }
 }


### PR DESCRIPTION
Generating a file ingest request for each file with the following values:
- the file's source path
- the file's target path
- a crc32c hash of the file's contents

@danxmoran I wasn't sure what you had in mind as the input for the method to create file ingest requests. I am using the pre-processed metadata as the input here, and added the "data file name" as a field on the pre-processed data so it could be passed in to this new method. If you prefer that I use the raw metadata as an input instead (to avoid messing with the `transformFileMetadata ` method), I would be happy to do that. Let me know what you think.