### PR TITLE
Update file metadata transformation to support new crc32c path

### DIFF
--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -133,7 +133,9 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     */
   def transformFileMetadata(entityType: String, fileName: String, metadata: Msg): Msg = {
     val (entityId, entityVersion) = getEntityIdAndVersion(fileName)
-    val contentHash = metadata.read[String]("file_core", "file_provenance", "crc32c")
+    val contentHash = metadata
+      .tryRead[String]("file_core", "file_provenance", "crc32c")
+      .getOrElse(metadata.read[String]("file_core", "crc32c"))
     val dataFileName = metadata.read[String]("file_core", "file_name")
     val (fileId, fileVersion) = getFileIdAndVersion(dataFileName)
     // put values in the form we want

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -133,7 +133,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     */
   def transformFileMetadata(entityType: String, fileName: String, metadata: Msg): Msg = {
     val (entityId, entityVersion) = getEntityIdAndVersion(fileName)
-    val contentHash = metadata.read[String]("file_core", "file_crc32c")
+    val contentHash = metadata.read[String]("file_core", "file_provenance", "crc32c")
     val dataFileName = metadata.read[String]("file_core", "file_name")
     val (fileId, fileVersion) = getFileIdAndVersion(dataFileName)
     // put values in the form we want

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -53,7 +53,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                |    "file_core": {
                |        "file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
                |        "format": "csv",
-               |        "file_crc32c": "54321zyx"
+               |        "file_provenance": { "crc32c": "54321zyx" }
                |    },
                |    "schema_type": "file"
                | }
@@ -71,7 +71,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           | {
           |   "some_file_entity_type_id": "entity-id",
           |   "version": "entity-version",
-          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_crc32c\":\"54321zyx\"},\"schema_type\":\"file\"}",
+          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_provenance\":{\"crc32c\":\"54321zyx\"}},\"schema_type\":\"file\"}",
           |   "crc32c": "54321zyx",
           |   "source_file_id": "some-id",
           |   "source_file_version": "some-version.numbers123",
@@ -90,7 +90,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                |    "file_core": {
                |        "file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
                |        "format": "json",
-               |        "file_crc32c": "abcd1234"
+               |        "file_provenance": { "crc32c": "abcd1234" }
                |    }
                | }
                |""".stripMargin
@@ -106,7 +106,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           | {
           |   "some_type_id": "123",
           |   "version": "456",
-          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_crc32c\":\"abcd1234\"}}",
+          |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_provenance\":{\"crc32c\":\"abcd1234\"}}}",
           |   "crc32c": "abcd1234",
           |   "source_file_id": "file-id",
           |   "source_file_version": "file-version",


### PR DESCRIPTION
The exact change to the file schema hasn't been ironed out yet, so it's likely this will change again. UCSC already updated their test bucket to match their best guess at the new layout, though, so we have to support it to continue testing.