### PR TITLE
Ra dspdc 1136 new checksums

### DIFF
--- a/schema/src/main/jade-tables/analysis_file.table.json
+++ b/schema/src/main/jade-tables/analysis_file.table.json
@@ -5,8 +5,6 @@
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
-    { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",

--- a/schema/src/main/jade-tables/analysis_file.table.json
+++ b/schema/src/main/jade-tables/analysis_file.table.json
@@ -6,7 +6,8 @@
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
     { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" }
+    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
+    { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",
   "datePartitionOptions": {

--- a/schema/src/main/jade-tables/image_file.table.json
+++ b/schema/src/main/jade-tables/image_file.table.json
@@ -5,8 +5,6 @@
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
-    { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",

--- a/schema/src/main/jade-tables/image_file.table.json
+++ b/schema/src/main/jade-tables/image_file.table.json
@@ -6,7 +6,8 @@
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
     { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" }
+    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
+    { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",
   "datePartitionOptions": {

--- a/schema/src/main/jade-tables/reference_file.table.json
+++ b/schema/src/main/jade-tables/reference_file.table.json
@@ -5,8 +5,6 @@
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
-    { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",

--- a/schema/src/main/jade-tables/reference_file.table.json
+++ b/schema/src/main/jade-tables/reference_file.table.json
@@ -6,7 +6,8 @@
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
     { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" }
+    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
+    { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",
   "datePartitionOptions": {

--- a/schema/src/main/jade-tables/sequence_file.table.json
+++ b/schema/src/main/jade-tables/sequence_file.table.json
@@ -5,8 +5,6 @@
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
-    { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",

--- a/schema/src/main/jade-tables/sequence_file.table.json
+++ b/schema/src/main/jade-tables/sequence_file.table.json
@@ -6,7 +6,8 @@
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
     { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" }
+    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
+    { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",
   "datePartitionOptions": {

--- a/schema/src/main/jade-tables/supplementary_file.table.json
+++ b/schema/src/main/jade-tables/supplementary_file.table.json
@@ -5,8 +5,6 @@
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
-    { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",

--- a/schema/src/main/jade-tables/supplementary_file.table.json
+++ b/schema/src/main/jade-tables/supplementary_file.table.json
@@ -6,7 +6,8 @@
     { "name": "content", "datatype": "string", "type": "required" },
     { "name": "file_id", "datatype": "fileref", "type": "required" },
     { "name": "source_file_id", "datatype": "string", "type": "required" },
-    { "name": "source_file_version", "datatype": "timestamp", "type": "required" }
+    { "name": "source_file_version", "datatype": "timestamp", "type": "required" },
+    { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitionMode": "date",
   "datePartitionOptions": {

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -154,7 +154,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         Str("version") -> Str(entityVersion),
         Str("content") -> Str(encode(metadata)),
         Str("virtual_path") -> Str(s"/$dataFileName"),
-        Str("crc32c") -> Str(descriptor.read[String]("crc32c")),
+        Str("crc32c") -> descriptor.read[Msg]("crc32c"),
         Str("descriptor") -> Str(encode(descriptor))
       )
     )

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -146,18 +146,15 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     descriptor: Msg
   ): Msg = {
     val (entityId, entityVersion) = getEntityIdAndVersion(fileName)
+    val dataFileName = descriptor.read[String]("file_name")
     // put values in the form we want
     Obj(
       mutable.LinkedHashMap[Msg, Msg](
         Str(s"${entityType}_id") -> Str(entityId),
         Str("version") -> Str(entityVersion),
         Str("content") -> Str(encode(metadata)),
-        Str("crc32c") -> Str(contentHash),
-        Str("source_file_id") -> Str(fileId),
-        Str("source_file_version") -> Str(fileVersion),
-        Str("virtual_path") -> Str(s"/$dataFileName")
+        Str("virtual_path") -> Str(s"/$dataFileName"),
         Str("crc32c") -> Str(descriptor.read[String]("crc32c")),
-        Str("data_file_name") -> Str(descriptor.read[String]("file_name")),
         Str("descriptor") -> Str(encode(descriptor))
       )
     )

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -86,10 +86,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "version": "entity-version",
           |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_provenance\":{\"crc32c\":\"54321zyx\"}},\"schema_type\":\"file\"}",
           |   "crc32c": "54321zyx",
-          |   "data_file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
-          |   "descriptor": "{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}"
-          |   "source_file_id": "some-id",
-          |   "source_file_version": "some-version.numbers123",
+          |   "descriptor": "{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}",
           |   "virtual_path": "/some-id_some-version.numbers123_12-34_metrics_are_fun.csv"
           | }
           |""".stripMargin
@@ -136,11 +133,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "version": "456",
           |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_provenance\":{\"crc32c\":\"abcd1234\"}}}",
           |   "crc32c": "54321zyx",
-          |   "data_file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
-          |   "descriptor": "{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}"
-          |   "crc32c": "abcd1234",
-          |   "source_file_id": "file-id",
-          |   "source_file_version": "file-version",
+          |   "descriptor": "{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}",
           |   "virtual_path": "/a-directory/sub_directory/file-id_file-version_filename.json"
           | }
           |""".stripMargin

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -60,10 +60,23 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                |""".stripMargin
     )
 
+    val exampleDescriptorContent = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |    "file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
+               |    "file_id": "my-file-id",
+               |    "file_version": "my-file-version",
+               |    "crc32c": "54321zyx",
+               |    "schema_type": "file_descriptor"
+               | }
+               |""".stripMargin
+    )
+
     val actualOutput = HcaPipelineBuilder.transformFileMetadata(
       entityType = "some_file_entity_type",
       fileName = "entity-id_entity-version.json",
-      metadata = exampleMetadataContent
+      metadata = exampleMetadataContent,
+      descriptor = exampleDescriptorContent
     )
     val expectedOutput = JsonParser.parseEncodedJson(
       json =
@@ -73,46 +86,10 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "version": "entity-version",
           |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_provenance\":{\"crc32c\":\"54321zyx\"}},\"schema_type\":\"file\"}",
           |   "crc32c": "54321zyx",
-          |   "source_file_id": "some-id",
-          |   "source_file_version": "some-version.numbers123",
-          |   "data_file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv"
-          | }
-          |""".stripMargin
-    )
-
-    actualOutput shouldBe expectedOutput
-  }
-
-  it should "be resilient to the old placement of crc32c" in {
-    val exampleMetadataContent = JsonParser.parseEncodedJson(
-      json = """
-               | {
-               |    "file_core": {
-               |        "file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
-               |        "format": "csv",
-               |        "crc32c": "54321zyx"
-               |    },
-               |    "schema_type": "file"
-               | }
-               |""".stripMargin
-    )
-
-    val actualOutput = HcaPipelineBuilder.transformFileMetadata(
-      entityType = "some_file_entity_type",
-      fileName = "entity-id_entity-version.json",
-      metadata = exampleMetadataContent
-    )
-    val expectedOutput = JsonParser.parseEncodedJson(
-      json =
-        """
-          | {
-          |   "some_file_entity_type_id": "entity-id",
-          |   "version": "entity-version",
-          |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"crc32c\":\"54321zyx\"},\"schema_type\":\"file\"}",
-          |   "crc32c": "54321zyx",
-          |   "source_file_id": "some-id",
-          |   "source_file_version": "some-version.numbers123",
-          |   "data_file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv"
+          |   "source_file_id": "my-file-id",
+          |   "source_file_version": "my-file-version",
+          |   "data_file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
+          |   "descriptor": "{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}"
           | }
           |""".stripMargin
     )
@@ -132,10 +109,23 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                | }
                |""".stripMargin
     )
+    val exampleDescriptorContent = JsonParser.parseEncodedJson(
+      json = """
+               | {
+               |    "file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
+               |    "file_id": "my-file-id",
+               |    "file_version": "my-file-version",
+               |    "crc32c": "54321zyx",
+               |    "schema_type": "file_descriptor"
+               | }
+               |""".stripMargin
+    )
+
     val actualOutput = HcaPipelineBuilder.transformFileMetadata(
       entityType = "some_type",
       fileName = "123_456.json",
-      metadata = exampleMetadataContent
+      metadata = exampleMetadataContent,
+      descriptor = exampleDescriptorContent
     )
     val expectedOutput = JsonParser.parseEncodedJson(
       json =
@@ -144,10 +134,11 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "some_type_id": "123",
           |   "version": "456",
           |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_provenance\":{\"crc32c\":\"abcd1234\"}}}",
-          |   "crc32c": "abcd1234",
-          |   "source_file_id": "file-id",
-          |   "source_file_version": "file-version",
-          |   "data_file_name": "a-directory/sub_directory/file-id_file-version_filename.json"
+          |   "crc32c": "54321zyx",
+          |   "source_file_id": "my-file-id",
+          |   "source_file_version": "my-file-version",
+          |   "data_file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
+          |   "descriptor": "{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}"
           | }
           |""".stripMargin
     )
@@ -166,7 +157,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
                |""".stripMargin
     )
     val actualOutput = HcaPipelineBuilder.transformLinksFileMetadata(
-      filename = "123_456_789.json",
+      fileName = "123_456_789.json",
       metadata = exampleMetadataContent
     )
     val expectedOutput = JsonParser.parseEncodedJson(

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -86,8 +86,6 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "version": "entity-version",
           |   "content": "{\"file_core\":{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"format\":\"csv\",\"file_provenance\":{\"crc32c\":\"54321zyx\"}},\"schema_type\":\"file\"}",
           |   "crc32c": "54321zyx",
-          |   "source_file_id": "my-file-id",
-          |   "source_file_version": "my-file-version",
           |   "data_file_name": "some-id_some-version.numbers123_12-34_metrics_are_fun.csv",
           |   "descriptor": "{\"file_name\":\"some-id_some-version.numbers123_12-34_metrics_are_fun.csv\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}"
           | }
@@ -135,8 +133,6 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
           |   "version": "456",
           |   "content": "{\"file_core\":{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"format\":\"json\",\"file_provenance\":{\"crc32c\":\"abcd1234\"}}}",
           |   "crc32c": "54321zyx",
-          |   "source_file_id": "my-file-id",
-          |   "source_file_version": "my-file-version",
           |   "data_file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
           |   "descriptor": "{\"file_name\":\"a-directory/sub_directory/file-id_file-version_filename.json\",\"file_id\":\"my-file-id\",\"file_version\":\"my-file-version\",\"crc32c\":\"54321zyx\",\"schema_type\":\"file_descriptor\"}"
           | }


### PR DESCRIPTION
Update the file metadata transformation pieces so that they use the new descriptor files. Also updates the schema for tables that end in "*_file" and updates relevant tests. Deleted one test case that doesn't apply anymore.