### PR TITLE
Ra dspdc 1128 schema validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,13 @@ lazy val `hca-schema` = project
 lazy val `hca-transformation-pipeline` = project
   .in(file("transformation"))
   .enablePlugins(MonsterScioPipelinePlugin)
+  .settings(
+    resolvers += "jitpack".at("https://jitpack.io"),
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %% "requests" % "0.5.1",
+      "io.circe" %% "circe-json-schema" % "0.1.0"
+    )
+  )
   .dependsOn(`hca-schema`)
 
 lazy val `hca-orchestration-workflow` = project

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -4,6 +4,10 @@ import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.ClosedTap
 import com.spotify.scio.values.SCollection
+
+import scala.util.{Failure, Success}
+import io.circe.parser._
+import io.circe.schema.Schema
 import org.apache.beam.sdk.io.{FileIO, ReadableFileCoder}
 import org.apache.beam.sdk.io.FileIO.ReadableFile
 import org.apache.beam.sdk.io.fs.EmptyMatchTreatment
@@ -27,6 +31,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     ()
   }
 
+  implicit def coderSchema: Coder[Schema] = Coder.kryo[Schema]
   implicit val readableFileCoder: Coder[ReadableFile] = Coder.beam(new ReadableFileCoder)
 
   // format is: {entity_type}/{entity_id}_{version}.json,
@@ -256,6 +261,45 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
   def encode(msg: Msg): String =
     upack.transform(msg, StringRenderer()).toString
 
+  def validateJson(value: SCollection[(String, Msg)]): Unit = {
+    // pull out the url for where the schema definition is for each file
+    val content = value.map {
+      case (filename, msg) => (msg.read[String]("describedBy"), (filename, msg))
+    }
+    // get the distinct urls (so as to minimize the number of get requests) and then get the schemas as strings
+    val schemas = content.map(_._1).distinct.map(url => (url, requests.get(url).text))
+    // join the schemas to the data keyed by the schema url
+    val joined = content.leftOuterJoin(schemas)
+    // go over each row
+    joined.map {
+      case (url, ((filename, data), schemaOption)) => {
+        // if there is nothing in the schemaOption, then something went wrong; if there is, try to validate
+        schemaOption match {
+          case Some(schema) => {
+            // if the schema is not able to load, throw an exception, otherwise try to use it to validate
+            Schema.loadFromString(schema) match {
+              case Failure(_) =>
+                throw new Exception(
+                  s"Schema not loaded properly for schema at $url, file $filename"
+                )
+              case Success(value) =>
+                // try to parse the actual data into a json format for validation
+                parse(data.str) match {
+                  case Left(_) =>
+                    throw new Exception(s"Unable to parse data into json for file $filename")
+                  // if everything is parsed/encoded/etc correctly, actually try to validate against schema here
+                  // if not valid, will return list of issues
+                  case Right(success) => value.validate(success)
+                }
+            }
+          }
+          case None => throw new Exception(s"No schema found at $url for file $filename")
+        }
+      }
+    }
+    ()
+  }
+
   /**
     * Read, transform, and write a given entity type.
     *
@@ -274,6 +318,8 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
     // get the readable files for the given input path
     val metadataFiles = getReadableFiles(s"$inputPrefix/metadata/${entityType}/**.json", context)
     val metadataFilenameAndMsg = jsonToFilenameAndMsg(entityType)(metadataFiles)
+
+    validateJson(metadataFilenameAndMsg)
 
     // for file metadata
     val processedMetadata = if (isFileMetadata) {

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -381,14 +381,17 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
       s"$inputPrefix/links/**.json",
       context
     )
+    val linksMetadataFilenameAndMsg = jsonToFilenameAndMsg("links")(readableFiles)
+
+    validateJson(linksMetadataFilenameAndMsg)
+
     // then convert json to msg and get the filename
-    val processedData =
-      jsonToFilenameAndMsg("links")(readableFiles)
-        .withName(s"Pre-process links metadata")
-        .map {
-          case (filename, metadata) =>
-            transformLinksFileMetadata(filename, metadata)
-        }
+    val processedData = linksMetadataFilenameAndMsg
+      .withName(s"Pre-process links metadata")
+      .map {
+        case (filename, metadata) =>
+          transformLinksFileMetadata(filename, metadata)
+      }
     // then write to storage
     StorageIO.writeJsonLists(
       processedData,

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -1,11 +1,16 @@
 package org.broadinstitute.monster.hca
 
+import com.spotify.scio.coders.Coder
+import com.spotify.scio.testing.PipelineSpec
+import io.circe.schema.Schema
 import org.broadinstitute.monster.common.msg.JsonParser
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
+class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec {
   behavior of "HcaPipelineBuilder"
+
+  implicit def coderSchema: Coder[Schema] = Coder.kryo[Schema]
 
   it should "transform basic metadata" in {
     val exampleFileContent = JsonParser.parseEncodedJson("""{"beep": "boop"}""")
@@ -199,5 +204,46 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers {
 
     actualHash shouldBe exampleHash
     actualOutput shouldBe expectedOutput
+  }
+
+  it should "validate json schemas" in {
+    val exampleFileContent = JsonParser.parseEncodedJson(
+      """
+        |{
+        |    "organ": {
+        |        "text": "brain",
+        |        "ontology": "astrocyte"
+        |    },
+        |    "schema_type": "biomaterial",
+        |    "biomaterial_core": {
+        |        "ncbi_taxon_id": [
+        |            9606
+        |        ],
+        |        "biomaterial_id": "Q4_DEMO-sample_SAMN02797092",
+        |        "has_input_biomaterial": "Q4_DEMO-donor_MGH30",
+        |        "biomaterial_name": "Q4_DEMO-Single cell mRNA-seq_MGH30_A01",
+        |        "supplementary_files": [
+        |            "Q4_DEMO-protocol"
+        |        ]
+        |    },
+        |    "organ_part": {
+        |        "text": "glioblastoma"
+        |    },
+        |    "genus_species": [
+        |        {
+        |            "text": "Homo sapiens",
+        |            "ontology": "NCBITaxon:9606"
+        |        }
+        |    ],
+        |    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism"
+        |}
+        |""".stripMargin
+    )
+
+//    val exampleUrlAndFile = (
+//      "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism",
+//      exampleFileContent
+//    )
+    runWithContext(sc => sc.parallelize(Seq(exampleFileContent)))
   }
 }

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -3,11 +3,17 @@ package org.broadinstitute.monster.hca
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.testing.PipelineSpec
 import io.circe.schema.Schema
+import org.broadinstitute.monster.common.PipelineCoders
 import org.broadinstitute.monster.common.msg.JsonParser
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.broadinstitute.monster.common.msg._
 
-class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec {
+class HcaPipelineBuilderSpec
+    extends AnyFlatSpec
+    with Matchers
+    with PipelineSpec
+    with PipelineCoders {
   behavior of "HcaPipelineBuilder"
 
   implicit def coderSchema: Coder[Schema] = Coder.kryo[Schema]
@@ -206,7 +212,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec
     actualOutput shouldBe expectedOutput
   }
 
-  it should "validate json schemas" in {
+  it should "validate json schemas and throw no exceptions if files are correctly formatted" in {
     val exampleFileContent = JsonParser.parseEncodedJson(
       """
         |{
@@ -240,10 +246,48 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec
         |""".stripMargin
     )
 
-//    val exampleUrlAndFile = (
-//      "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism",
-//      exampleFileContent
-//    )
-    runWithContext(sc => sc.parallelize(Seq(exampleFileContent)))
+    val exampleUrlAndFile = (exampleFileContent.read[String]("describedBy"), exampleFileContent)
+
+    runWithContext(sc => HcaPipelineBuilder.validateJson(sc.parallelize(Seq(exampleUrlAndFile))))
+  }
+
+  it should "validate json schemas and throw an exception if files are incorrectly formatted" in {
+    val exampleFileContent = JsonParser.parseEncodedJson(
+      """
+        |{
+        |    "organ": {
+        |        "text": "brain",
+        |        "ontology": "astrocyte"
+        |    },
+        |    "biomaterial_core": {
+        |        "ncbi_taxon_id": [
+        |            9606
+        |        ],
+        |        "biomaterial_id": "Q4_DEMO-sample_SAMN02797092",
+        |        "has_input_biomaterial": "Q4_DEMO-donor_MGH30",
+        |        "biomaterial_name": "Q4_DEMO-Single cell mRNA-seq_MGH30_A01",
+        |        "supplementary_files": [
+        |            "Q4_DEMO-protocol"
+        |        ]
+        |    },
+        |    "organ_part": {
+        |        "text": "glioblastoma"
+        |    },
+        |    "genus_species": [
+        |        {
+        |            "text": "Homo sapiens",
+        |            "ontology": "NCBITaxon:9606"
+        |        }
+        |    ],
+        |    "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism"
+        |}
+        |""".stripMargin
+    )
+
+    val exampleUrlAndFile = (exampleFileContent.read[String]("describedBy"), exampleFileContent)
+
+    the[Exception] thrownBy runWithContext { sc =>
+      HcaPipelineBuilder.validateJson(sc.parallelize(Seq(exampleUrlAndFile)))
+    } should have message "java.lang.Exception: Data does not conform to schema: NonEmptyList(#: required key [schema_type] not found)"
   }
 }


### PR DESCRIPTION
Add json schema validation to our piece of the HCA pipeline. Between the additional Circe JSON encoding and the requests-scala library, I don't think this is very high performance, but it sure seems to work.