### PR TITLE
ra-DSPDC-1234-schema-fix

### DIFF
--- a/schema/src/main/jade-tables/analysis_file.table.json
+++ b/schema/src/main/jade-tables/analysis_file.table.json
@@ -4,7 +4,7 @@
     { "name": "analysis_file_id", "datatype": "string", "type": "primary_key" },
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
-    { "name": "file_id", "datatype": "fileref", "type": "required" },
+    { "name": "file_id", "datatype": "fileref"},
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitioning": {

--- a/schema/src/main/jade-tables/image_file.table.json
+++ b/schema/src/main/jade-tables/image_file.table.json
@@ -4,7 +4,7 @@
     { "name": "image_file_id", "datatype": "string", "type": "primary_key" },
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
-    { "name": "file_id", "datatype": "fileref", "type": "required" },
+    { "name": "file_id", "datatype": "fileref"},
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitioning": {

--- a/schema/src/main/jade-tables/reference_file.table.json
+++ b/schema/src/main/jade-tables/reference_file.table.json
@@ -4,7 +4,7 @@
     { "name": "reference_file_id", "datatype": "string", "type": "primary_key" },
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
-    { "name": "file_id", "datatype": "fileref", "type": "required" },
+    { "name": "file_id", "datatype": "fileref"},
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitioning": {

--- a/schema/src/main/jade-tables/sequence_file.table.json
+++ b/schema/src/main/jade-tables/sequence_file.table.json
@@ -4,7 +4,7 @@
     { "name": "sequence_file_id", "datatype": "string", "type": "primary_key" },
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
-    { "name": "file_id", "datatype": "fileref", "type": "required" },
+    { "name": "file_id", "datatype": "fileref"},
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitioning": {

--- a/schema/src/main/jade-tables/supplementary_file.table.json
+++ b/schema/src/main/jade-tables/supplementary_file.table.json
@@ -4,7 +4,7 @@
     { "name": "supplementary_file_id", "datatype": "string", "type": "primary_key" },
     { "name": "version", "datatype": "timestamp", "type": "primary_key" },
     { "name": "content", "datatype": "string", "type": "required" },
-    { "name": "file_id", "datatype": "fileref", "type": "required" },
+    { "name": "file_id", "datatype": "fileref"},
     { "name": "descriptor", "datatype": "string", "type": "required" }
   ],
   "partitioning": {


### PR DESCRIPTION
make all file_id columns for all 5 file entity types nullable. "nullable" is the default type for external file definitions for bigquery, so simply removing the "required" type should be sufficient. This ought to ensure that the joins from file in our argo workflow work, since the error was that the required field of "file_id" was not present, and now it should not be parsed as required and the workflow should be able to move past it.