### PR TITLE
ra-DSPDC-1284-change-target-path

### DIFF
--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -198,7 +198,7 @@ class HcaPipelineBuilderSpec
         """
           | {
           |   "source_path": "some/local/directory/data/a-directory/sub_directory/file-id_file-version_filename.json",
-          |   "target_path": "/foo_file/54321zyx"
+          |   "target_path": "/foo_file/file-id_file-version_filename.json"
           | }
           |""".stripMargin
     )


### PR DESCRIPTION
updates targetPath value to contain the filename with extension; will update all getOrElse exception throwing to error logging in a separate PR. Updated test for file ingest request generation as well.