### PR TITLE
Ra no max failures

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -15,7 +15,7 @@ jobs:
           project_id: ${{ secrets.DEV_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_TEST_KEY }}
           export_default_credentials: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
           project_id: ${{ secrets.DEV_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_TEST_KEY }}
           export_default_credentials: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -245,7 +245,7 @@ spec:
                 - name: load-tag
                   value: {{ printf "%s-%s" $loadTagPrefix $controlFileIndex | quote }}
                 - name: max-failures
-                  value: 0
+                  value: 10
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
           {{- $jobId := "{{tasks.submit.outputs.result}}" }}

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -245,7 +245,7 @@ spec:
                 - name: load-tag
                   value: {{ printf "%s-%s" $loadTagPrefix $controlFileIndex | quote }}
                 - name: max-failures
-                  value: 10
+                  value: 0
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
           {{- $jobId := "{{tasks.submit.outputs.result}}" }}

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -245,7 +245,7 @@ spec:
                 - name: load-tag
                   value: {{ printf "%s-%s" $loadTagPrefix $controlFileIndex | quote }}
                 - name: max-failures
-                  value: {{ $totalFileCount | quote }}
+                  value: 0
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
           {{- $jobId := "{{tasks.submit.outputs.result}}" }}

--- a/orchestration/values.yaml
+++ b/orchestration/values.yaml
@@ -1,9 +1,9 @@
 dataflow:
   region: us-central1
-  workerMachineType: n1-standard-2
+  workerMachineType: n1-standard-4
   autoscaling:
     minWorkers: 4
-    maxWorkers: 8
+    maxWorkers: 16
   useFlexRS: false
 repo:
   pollTimeout: 86400
@@ -20,4 +20,4 @@ argoTemplates:
   softDeleteTable:
     create: true
     name: soft-delete-table
-parallelism: 4
+parallelism: 8


### PR DESCRIPTION
## Why
Bulk file ingests should fail fast particularly when there is the same issue for all the files and all of them fail.
Dataflow and Argo could both perform a little better with more resources, which is helpful for getting imports done quickly.

## This PR
- Set max failures for bulk file ingests to 0 so that Jade will fail fast on file ingests
- Bump up dataflow machine type and max number of worker params
- Bump up parallelism for argo workflows