### PR TITLE
ra DSPDC 1382 fix join

### DIFF
--- a/orchestration/scripts/inject-file-ids.sh
+++ b/orchestration/scripts/inject-file-ids.sh
@@ -22,7 +22,8 @@ declare -ra BQ_QUERY=(
 1>&2 ${BQ_QUERY[@]} "SELECT S.${TABLE}_id, S.version, J.file_id, S.content, S.descriptor
   FROM ${TABLE} S LEFT JOIN \`${JADE_PROJECT}.${JADE_DATASET}.datarepo_load_history\` J
   ON J.state = 'succeeded'
-  AND JSON_EXTRACT_SCALAR(S.descriptor, '$.crc32c') = J.checksum_crc32c"
+  AND JSON_EXTRACT_SCALAR(S.descriptor, '$.crc32c') = J.checksum_crc32c
+  AND ${GCS_DATA_DIR} || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_name') = J.source_name"
 
 # Echo the output table name to Argo can slurp it into a parameter.
 echo ${TARGET_TABLE}

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -443,6 +443,8 @@ spec:
         env:
           - name: GCS_PREFIX
             value: {{ printf "gs://%s/%s/%s" .Values.gcs.stagingBucketName $gcsPrefix $table | quote }}
+          - name: GCS_DATA_DIR
+            value: {{ printf "gs://%s/%s/data/" .Values.gcs.stagingBucketName $gcsPrefix | quote }}
           - name: TABLE
             value: {{ $table | quote }}
           - name: STAGING_PROJECT


### PR DESCRIPTION
## Why
We've had a number of issues due to crc32c checksums not being unique across the number of files we have to deal with. When injecting file ids, we need to check more than just the crc32c. Per import, checking by the source file path should be unique.

## This PR
make file-id-injection join use a combo of the checksum and the source file name; the source file name for a given import must be unique, so no collisions should occur