### PR TITLE
Ra dspdc 1348 fix remove script

### DIFF
--- a/orchestration/scripts/inject-file-ids.sh
+++ b/orchestration/scripts/inject-file-ids.sh
@@ -22,7 +22,8 @@ declare -ra BQ_QUERY=(
 1>&2 ${BQ_QUERY[@]} "SELECT S.${TABLE}_id, S.version, J.file_id, S.content, S.descriptor
   FROM ${TABLE} S LEFT JOIN \`${JADE_PROJECT}.${JADE_DATASET}.datarepo_load_history\` J
   ON J.state = 'succeeded'
-  AND JSON_EXTRACT_SCALAR(S.descriptor, '$.crc32c') = J.checksum_crc32c"
+  AND JSON_EXTRACT_SCALAR(S.descriptor, '$.crc32c') = J.checksum_crc32c
+  AND ${GCS_DATA_DIR} || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_name') = J.source_name"
 
 # Echo the output table name to Argo can slurp it into a parameter.
 echo ${TARGET_TABLE}

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -443,6 +443,8 @@ spec:
         env:
           - name: GCS_PREFIX
             value: {{ printf "gs://%s/%s/%s" .Values.gcs.stagingBucketName $gcsPrefix $table | quote }}
+          - name: GCS_DATA_DIR
+            value: {{ printf "gs://%s/%s/data/" .Values.gcs.stagingBucketName $gcsPrefix | quote }}
           - name: TABLE
             value: {{ $table | quote }}
           - name: STAGING_PROJECT

--- a/scripts/hca-utils/hca_utils/utils.py
+++ b/scripts/hca-utils/hca_utils/utils.py
@@ -144,7 +144,7 @@ class HcaUtils:
         bucket = storage_client.bucket(self.bucket)
         target_filename = self._format_filename(table=target_table)
         blob = bucket.blob(target_filename)
-        blob.upload_from_file(local_file, rewind=True)
+        blob.upload_from_file(local_file)
 
         filepath = f"gs://{self.bucket}/{target_filename}"
         print(f"Put a soft-delete file here: {filepath}")

--- a/scripts/hca-utils/hca_utils/utils.py
+++ b/scripts/hca-utils/hca_utils/utils.py
@@ -1,7 +1,6 @@
 import csv
 import os
 from requests.exceptions import HTTPError
-import tempfile
 from typing import Set
 import urllib.parse
 
@@ -133,28 +132,19 @@ class HcaUtils:
 
         sd_writer.writerows([[rid] for rid in row_ids])
 
-    @staticmethod
-    def delete_csv(filename: str):
-        """
-        Remove the csv after it has been uploaded so that there isn't a deluge of csv files in the local directory.
-        :param filename: The filename of the file to delete.
-        :return:
-        """
-        os.remove(filename)
-
     # gcs (cloud storage) interactions
-    def put_csv_in_bucket(self, local_filename: str, target_table: str) -> str:
+    def put_csv_in_bucket(self, local_file, target_table: str) -> str:
         """
         Puts a local file into a GCS bucket accessible by Jade.
-        :param local_filename: The filename of the file to upload.
-        :param target_table: The table name with which to fomrat the target filename.
+        :param local_file: The file to upload.
+        :param target_table: The table name with which to format the target filename.
         :return: The gs-path of the uploaded file.
         """
         storage_client = storage.Client(project=self.bucket_project, credentials=self.gcp_creds)
         bucket = storage_client.bucket(self.bucket)
-        blob = bucket.blob(local_filename)
-        blob.upload_from_filename(local_filename)
         target_filename = self._format_filename(table=target_table)
+        blob = bucket.blob(target_filename)
+        blob.upload_from_file(local_file, rewind=True)
 
         filepath = f"gs://{self.bucket}/{target_filename}"
         print(f"Put a soft-delete file here: {filepath}")
@@ -288,8 +278,10 @@ class HcaUtils:
         delete the problematic rows.
         :return:
         """
+        print("Processing, deleting as we find anything...")
         self.process_duplicates(soft_delete=True)
         self.process_null_file_refs(soft_delete=True)
+        print("Finished.")
 
     def _process_rows(self, get_table_names, get_rids, soft_delete: bool, issue: str):
         """
@@ -305,8 +297,16 @@ class HcaUtils:
             if len(rids_to_process) > 0:
                 print(f"{table_name} has {len(rids_to_process)} rows to soft delete due to {issue}")
                 if soft_delete:
-                    with tempfile.NamedTemporaryFile() as tf:
-                        self.populate_row_id_csv(rids_to_process, tf)
-                        remote_file_path = self.put_csv_in_bucket(local_filename=tf.name, target_table=table_name)
-                        job_id = self.submit_soft_delete(table_name, remote_file_path)
-                    print(f"Soft delete job for table {table_name} running, job id of: {job_id}")
+                    local_filename = f"{os.getcwd()}/{table_name}.csv"
+                    try:
+                        # create and populate file
+                        with open(local_filename, mode="w") as wf:
+                            self.populate_row_id_csv(rids_to_process, wf)
+                        # do processing
+                        with open(local_filename, mode="rb") as rf:
+                            remote_file_path = self.put_csv_in_bucket(local_file=rf, target_table=table_name)
+                            job_id = self.submit_soft_delete(table_name, remote_file_path)
+                            print(f"Soft delete job for table {table_name} running, job id of: {job_id}")
+                    finally:
+                        # delete file
+                        os.remove(local_filename)


### PR DESCRIPTION
## Why
The "remove" option for the hca post processing tool was no longer working as a result of some refactors having to do with temporary files.

## This PR
Updates the code to make sure the file creation, writing, reading/uploading, and deletion work as intended.