### PR TITLE
Quote data dir var to avoid a syntax error

### DIFF
--- a/orchestration/scripts/inject-file-ids.sh
+++ b/orchestration/scripts/inject-file-ids.sh
@@ -23,7 +23,7 @@ declare -ra BQ_QUERY=(
   FROM ${TABLE} S LEFT JOIN \`${JADE_PROJECT}.${JADE_DATASET}.datarepo_load_history\` J
   ON J.state = 'succeeded'
   AND JSON_EXTRACT_SCALAR(S.descriptor, '$.crc32c') = J.checksum_crc32c
-  AND ${GCS_DATA_DIR} || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_name') = J.source_name"
+  AND '${GCS_DATA_DIR}' || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_name') = J.source_name"
 
 # Echo the output table name to Argo can slurp it into a parameter.
 echo ${TARGET_TABLE}


### PR DESCRIPTION
## Why
The `inject-file-ids` workflow script is dying due to a syntax error in our BigQuery syntax:
```
Syntax error: Expected end of input but got ":" at [5:9]
```
Reproing this in the bq console shows that we're not properly escaping the gcs data dir variable.

## This PR
* Escapes the gcs data dir variable