### PR TITLE
Pull in the latest ingest-utils to fix missing graal docker image

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.3")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -389,7 +389,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
           generateFileIngestRequest(descriptor, inputPrefix)
       }.distinctByKey.values
 
-      StorageIO.writeJsonLists(
+      StorageIO.writeJsonListsGeneric(
         fileIngestRequests,
         entityType,
         s"$outputPrefix/data-transfer-requests/$entityType"
@@ -405,7 +405,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         }
     }
     // then write to storage
-    StorageIO.writeJsonLists(
+    StorageIO.writeJsonListsGeneric(
       processedMetadata,
       entityType,
       s"$outputPrefix/metadata/$entityType"
@@ -434,7 +434,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
           transformLinksFileMetadata(filename, metadata, inputPrefix)
       }
     // then write to storage
-    StorageIO.writeJsonLists(
+    StorageIO.writeJsonListsGeneric(
       processedData,
       "links",
       s"$outputPrefix/metadata/links"


### PR DESCRIPTION
## Why
The oracle graal docker image we use has been removed, this upgrades to a newer version of ingest-utils with an updated docker image.

## This PR
* Upgrades the ingest-utils version
* Fixes calls to `writeJsonLists` to use the updated naming.