### PR TITLE
Deduplicate ingest requests by file UUID instead of CRC32C

### DIFF
--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -225,13 +225,13 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
   ): (String, Msg) = {
     val targetPath = descriptor
       .read[String]("file_name")
-    val contentHash = descriptor
-      .read[String]("crc32c")
+    val contentId = descriptor
+      .read[String]("file_id")
 
-    contentHash -> Obj(
+    contentId -> Obj(
       Str("source_path") -> Str(s"$inputPrefix/data/$targetPath"),
       Str("target_path") -> Str(
-        s"/$contentHash/${targetPath.substring(targetPath.lastIndexOf("/") + 1)}"
+        s"/$contentId/${targetPath.substring(targetPath.lastIndexOf("/") + 1)}"
       )
     )
   }

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -182,19 +182,19 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec
   }
 
   it should "correctly generate file ingest requests" in {
-    val exampleHash = "54321zyx"
+    val exampleId = "my-file-id"
     val exampleDescriptor = JsonParser.parseEncodedJson(
       json = s"""
                 | {
                 |    "file_name": "a-directory/sub_directory/file-id_file-version_filename.json",
-                |    "file_id": "my-file-id",
+                |    "file_id": "$exampleId",
                 |    "file_version": "my-file-version",
-                |    "crc32c": "$exampleHash",
+                |    "crc32c": "54321zyx",
                 |    "schema_type": "file_descriptor"
                 | }
                 |""".stripMargin
     )
-    val (actualHash, actualOutput) = HcaPipelineBuilder
+    val (actualId, actualOutput) = HcaPipelineBuilder
       .generateFileIngestRequest(
         descriptor = exampleDescriptor,
         inputPrefix = "some/local/directory"
@@ -204,12 +204,12 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec
         """
           | {
           |   "source_path": "some/local/directory/data/a-directory/sub_directory/file-id_file-version_filename.json",
-          |   "target_path": "/54321zyx/file-id_file-version_filename.json"
+          |   "target_path": "/my-file-id/file-id_file-version_filename.json"
           | }
           |""".stripMargin
     )
 
-    actualHash shouldBe exampleHash
+    actualId shouldBe exampleId
     actualOutput shouldBe expectedOutput
   }
 


### PR DESCRIPTION
We were previously encountering requests for different files being erroneously deduplicated, since crc32c only allows the standard assumptions for a hash (i.e. two identical files will have the same hash, but different files will not necessarily have different hashes). Using the UUID associated with a file instead will ensure that we encounter no erroneous duplicates within the next few millennia.