### PR TITLE
Join on target_path when determining the file ID to pull

### DIFF
--- a/orchestration/scripts/inject-file-ids.sh
+++ b/orchestration/scripts/inject-file-ids.sh
@@ -23,7 +23,7 @@ declare -ra BQ_QUERY=(
   FROM ${TABLE} S LEFT JOIN \`${JADE_PROJECT}.${JADE_DATASET}.datarepo_load_history\` J
   ON J.state = 'succeeded'
   AND JSON_EXTRACT_SCALAR(S.descriptor, '$.crc32c') = J.checksum_crc32c
-  AND '${GCS_DATA_DIR}' || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_name') = J.source_name"
+  AND '/' || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_id') || '/' || JSON_EXTRACT_SCALAR(S.descriptor, '$.file_name') = J.target_path"
 
 # Echo the output table name to Argo can slurp it into a parameter.
 echo ${TARGET_TABLE}


### PR DESCRIPTION
## Why 
The validation tool found null file refs in the Prod dataset after running our Feb ingests. After much sleuthing, we determined that it was due to a `reference_file` being included in multiple staging areas ([related bug ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1568))

Specifically, the `inject-file-ids.sh` script was using the `source_name` of the jade `datarepo_load_history` table as the join point. This does not work when a file is present in multiple staging areas. 


For example, assume a file with `reference_file` metadata is ingested, with `source_name` = `gs://source_staging_bucket/data/file_a`, `file_id` = `some_file_id` in ingest 1. The following process takes place:
* The data file is ingested by Jade and a row is inserted in the `datarepo_load_history` table with a `source_name` of `gs://source_staging_bucket/data/file_a`, a `target_path` of `some_uuid/file_a` (note that our scheme for synthesizing `target_path` changed in [this PR](https://github.com/DataBiosphere/hca-ingest/pull/50)) and a `file_id` of `some_file_id`
* `inject-file-ids.sh` runs against the `datarepo_load_history` table and successfully `left join`s using `gs://source_staging_bucket/data/file_a` as the `source_name` join point (I am ignoring crc32 for simplicity of explanation)
* A metadata row is inserted into `reference_file` with values `file_id` = `some_file_id`

Now assume another `reference_file` metadata file is ingested in ingest 2, with identical `file_id` but a *different* `source_name` = `gs://another_source_staging_bucket/data/file_a`. 
* We skip ingesting the file as an entry exists in `datarepo_load_history` with the same `target_path` (see here for the [underlying query](https://github.com/DataBiosphere/hca-ingest/blob/a499345f0a075023cafef88cd32d00b510de4419/orchestration/scripts/diff-data-files.sh#L22-L27))
* `inject-file-ids.sh` runs against the `datarepo_load_history` table, now *unsuccessfully* `left join`ing using `gs://another_source_staging_bucket/data/file_a`. The file metadata for ingestion *does not receive* a file ID.
* However, a new version of the metadata row for the same `reference_file` is created, with a NULL `file_id` (the old version is soft deleted in a related step).

## This PR
* Changes the join point from `source_name` to `target_path`, constructs a `target_path` for the left-side join by concatenating the relevant descriptor elements, and using the existing Jade `datarepo_load_history.target_path` field as the right-side of the join. 

## TODO
* We should yell very loudly when a metadata row is going to be constructed with a null file ref. 
