### PR TITLE
Add helmfile lockfile

### DIFF
--- a/ops/helmfiles/dagster/helmfile.lock
+++ b/ops/helmfiles/dagster/helmfile.lock
@@ -1,0 +1,10 @@
+version: v0.138.4
+dependencies:
+- name: dagster
+  repository: https://dagster-io.github.io/helm
+  version: 0.10.7
+- name: serviceaccount-psp
+  repository: https://broadinstitute.github.io/datarepo-helm
+  version: 0.0.3
+digest: sha256:d3d95802fcc21ec2ad478affea8b832387a7c41e81bed598aa822c7d6363f403
+generated: "2021-02-26T15:48:17.819246-05:00"

--- a/ops/helmfiles/dagster/helmfile.yaml
+++ b/ops/helmfiles/dagster/helmfile.yaml
@@ -20,7 +20,6 @@ releases:
     namespace: dagster   # target namespace
     chart: dagster/dagster   # chart name
     missingFileHandler: Warn
-    version: ~0.10.7
     values:
       - rbacEnabled: true
       - postgresql:

--- a/ops/helmfiles/dagster/helmfile.yaml
+++ b/ops/helmfiles/dagster/helmfile.yaml
@@ -20,6 +20,7 @@ releases:
     namespace: dagster   # target namespace
     chart: dagster/dagster   # chart name
     missingFileHandler: Warn
+    version: ~0.10.7
     values:
       - rbacEnabled: true
       - postgresql:


### PR DESCRIPTION
## Why
We should pin our helm dependencies to avoid unwanted upgrades and have a more reproducible environment.

## This PR
* Adds a helmfile [lockfile ](https://github.com/roboll/helmfile#deps)and pins us at dagster 0.10.7