### PR TITLE
Add sensor to trigger egress validation when HCA import completes in Argo

### DIFF
--- a/ops/helmfiles/dagster/environment/dev.yaml
+++ b/ops/helmfiles/dagster/environment/dev.yaml
@@ -6,5 +6,5 @@ data:
   # all of these key-value pairs get injected as environment variables into the containers running dagster,
   # including the dagit ui server and any pipeline executors
   HCA_ARGO_URL: https://hca-argo.monster-dev.broadinstitute.org/
-  HCA_GOOGLE_PROJECT: aaaaa
+  HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-dev
   HCA_GCP_ENV: dev

--- a/ops/helmfiles/dagster/environment/dev.yaml
+++ b/ops/helmfiles/dagster/environment/dev.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hca-dagster-dev-config
+data:
+  # all of these key-value pairs get injected as environment variables into the containers running dagster,
+  # including the dagit ui server and any pipeline executors
+  HCA_ARGO_URL: https://hca-argo.monster-dev.broadinstitute.org/
+  HCA_GOOGLE_PROJECT: aaaaa

--- a/ops/helmfiles/dagster/environment/dev.yaml
+++ b/ops/helmfiles/dagster/environment/dev.yaml
@@ -7,3 +7,4 @@ data:
   # including the dagit ui server and any pipeline executors
   HCA_ARGO_URL: https://hca-argo.monster-dev.broadinstitute.org/
   HCA_GOOGLE_PROJECT: aaaaa
+  HCA_GCP_ENV: dev

--- a/ops/helmfiles/dagster/environment/prod.yaml
+++ b/ops/helmfiles/dagster/environment/prod.yaml
@@ -6,5 +6,5 @@ data:
   # all of these key-value pairs get injected as environment variables into the containers running dagster,
   # including the dagit ui server and any pipeline executors
   HCA_ARGO_URL: https://hca-argo.monster-prod.broadinstitute.org/
-  HCA_GOOGLE_PROJECT: aaaaa
+  HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-prod
   HCA_GCP_ENV: prod

--- a/ops/helmfiles/dagster/environment/prod.yaml
+++ b/ops/helmfiles/dagster/environment/prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hca-dagster-prod-config
+data:
+  # all of these key-value pairs get injected as environment variables into the containers running dagster,
+  # including the dagit ui server and any pipeline executors
+  HCA_ARGO_URL: https://hca-argo.monster-prod.broadinstitute.org/
+  HCA_GOOGLE_PROJECT: aaaaa

--- a/ops/helmfiles/dagster/environment/prod.yaml
+++ b/ops/helmfiles/dagster/environment/prod.yaml
@@ -7,3 +7,4 @@ data:
   # including the dagit ui server and any pipeline executors
   HCA_ARGO_URL: https://hca-argo.monster-prod.broadinstitute.org/
   HCA_GOOGLE_PROJECT: aaaaa
+  HCA_GCP_ENV: prod

--- a/ops/helmfiles/dagster/helmfile.yaml
+++ b/ops/helmfiles/dagster/helmfile.yaml
@@ -26,6 +26,9 @@ releases:
           serviceAccount:
             enabled: true
             name: monster-dagster
+      - dagit:
+          envConfigMaps:
+            - name: hca-dagster-{{ env "ENV" }}-config
       - userDeployments:
           # "user code" we deploy to dagster; these are dagster repositories of pipelines
           enabled: true
@@ -39,5 +42,17 @@ releases:
                 - "-f"
                 - "/hca_orchestration/pipelines.py"
               port: 3030
+              envConfigMaps:
+                - name: hca-dagster-{{ env "ENV" }}-config
+      - runLauncher:
+          config:
+            # k8s run launcher is the default, we'll need to change this bit if we switch to a
+            # different run launcher
+            k8sRunLauncher:
+              envConfigMaps:
+                - name: hca-dagster-{{ env "ENV" }}-config
+      - dagsterDaemon:
+          envConfigMaps:
+            - name: hca-dagster-{{ env "ENV" }}-config
 
 

--- a/orchestration/dagster_orchestration/Dockerfile
+++ b/orchestration/dagster_orchestration/Dockerfile
@@ -19,6 +19,7 @@ RUN \
         google-cloud-storage==1.33.0 \
         requests-cache==0.5.2 \
         data-repo-client==1.0.194.post5 \
+        argo-workflows==5.0.0
 # Cleanup
     &&  rm -rf /var \
     &&  rm -rf /root/.cache  \

--- a/orchestration/dagster_orchestration/Dockerfile
+++ b/orchestration/dagster_orchestration/Dockerfile
@@ -19,7 +19,7 @@ RUN \
         google-cloud-storage==1.33.0 \
         requests-cache==0.5.2 \
         data-repo-client==1.0.194.post5 \
-        argo-workflows==5.0.0
+        argo-workflows==5.0.0 \
 # Cleanup
     &&  rm -rf /var \
     &&  rm -rf /root/.cache  \

--- a/orchestration/dagster_orchestration/README.md
+++ b/orchestration/dagster_orchestration/README.md
@@ -1,7 +1,7 @@
 # Notes
 
 This is an initial introduction of [Dagster](https://dagster.io)
-into our codebase for workflow orchestration. This document captures notes, 
+into our codebase for workflow orchestration. This document captures notes,
 todos and anything else we bump into as we test out this technology.
 
 ## Running
@@ -12,7 +12,7 @@ We're using poetry:
 The `stage_data` pipeline is being built to mimic our current HCA `stage_data` pipeline.
 
 The `pre_process_metadata` solid kicks off a Beam job, either locally or in GCP depending
-on which Dagster mode you're running in. 
+on which Dagster mode you're running in.
 
 ## Deployment notes
 These are WIP steps + notes to getting code deployed.
@@ -27,7 +27,6 @@ deployment. This is how we enumerate the "deployables"; right now we have a sing
   * Make sure you are configured to push to the `hca-dev` GCR.
   * Build a docker image, tagging with the current git SHA: `GIT_SHORTHASH="$(git rev-parse --short HEAD)" && docker build . --build-arg DAGSTER_VERSION=0.10.4 -t us.gcr.io/broad-dsp-monster-hca-dev/monster-dagster:$GIT_SHORTHASH`
   * `GIT_SHORTHASH="$(git rev-parse --short HEAD)" && docker push  us.gcr.io/broad-dsp-monster-hca-dev/monster-dagster:$GIT_SHORTHASH`
-  * Run `helmfile` against the new sha as well to update GKE: `SHORTHASH="$(git rev-parse --short HEAD)" helmfile apply" 
+  * Run `helmfile` against the new sha as well to update GKE: `ENV=dev GIT_SHORTHASH="$(git rev-parse --short HEAD)" helmfile apply"
   * GKE should pick up the updated image and deploy
-
 You must port forward to be able to access the `dagit` UI in our HCA GCP project: `kubectl port-forward --namespace dagster svc/monster-dagit 8080:80`

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/README.md
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/README.md
@@ -1,0 +1,3 @@
+# contrib
+
+Any libraries used to interact with external services that aren't defined as Dagster-specific concepts (e.g. resources) go in here.

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
@@ -1,10 +1,14 @@
+from __future__ import annotations  # this lets us annotate functions in class C that return an instance of C
+
+from typing import Any, Callable, Dict, Generator, Optional
+
 from argo.workflows.client import ApiClient as ArgoApiClient,\
                                   ArchivedWorkflowServiceApi,\
                                   Configuration as ArgoConfiguration
-from argo.workflows.client.models import V1alpha1Workflow
+from argo.workflows.client.models import V1alpha1Workflow, V1alpha1WorkflowList
 
 
-def generate_argo_archived_workflows_client(host_url, access_token):
+def generate_argo_archived_workflows_client(host_url: str, access_token: str) -> ArchivedWorkflowServiceApi:
     return ArchivedWorkflowServiceApi(
         api_client=ArgoApiClient(
             configuration=ArgoConfiguration(host=host_url),
@@ -13,22 +17,22 @@ def generate_argo_archived_workflows_client(host_url, access_token):
 
 
 class ArgoArchivedWorkflowsClientMixin:
-    def __init__(self, *args, argo_url, access_token, **kwargs):
+    def __init__(self, *args, argo_url: str, access_token: str, **kwargs):
         super().__init__(*args, **kwargs)
         self.argo_url = argo_url
         self.access_token = access_token
         self._client = None
 
-    def client(self):
+    def client(self) -> ArchivedWorkflowServiceApi:
         if not self._client:
             self._client = generate_argo_archived_workflows_client(self.argo_url, self.access_token)
 
         return self._client
 
-    def list_archived_workflows(self):
-        self._pull_paginated_results(self.client().list_archived_workflows)
+    def list_archived_workflows(self) -> Generator[V1alpha1Workflow, None, None]:
+        return self._pull_paginated_results(self.client().list_archived_workflows)
 
-    def _pull_paginated_results(self, api_function):
+    def _pull_paginated_results(self, api_function: Callable[[Optional[str]], V1alpha1WorkflowList]) -> Generator[V1alpha1Workflow, None, None]:
         results = api_function()
 
         for result in results.items:
@@ -47,19 +51,20 @@ class ExtendedArgoWorkflow(ArgoArchivedWorkflowsClientMixin):
         self._workflow = workflow
         self._inflated = False
 
-    def inflate(self):
+    def inflate(self) -> ExtendedArgoWorkflow:
         if not self._inflated:
             self._workflow = self.client().get_archived_workflow(self.metadata.uid)
             self._inflated = True
 
         return self
 
-    def params_dict(self):
+    def params_dict(self) -> Dict[str, Any]:
         return {
             param.name: param.value
             for param in self.spec.arguments.parameters
         }
 
+    # proxy pattern - any function calls not defined in this class are passed to the wrapped workflow object
     def __getattr__(self, name):
         return getattr(self._workflow, name)
 

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
@@ -1,0 +1,67 @@
+from argo.workflows.client import ApiClient as ArgoApiClient,\
+                                  ArchivedWorkflowServiceApi,\
+                                  Configuration as ArgoConfiguration
+from argo.workflows.client.models import V1alpha1Workflow
+
+
+def generate_argo_archived_workflows_client(host_url, access_token):
+    return ArchivedWorkflowServiceApi(
+        api_client=ArgoApiClient(
+            configuration=ArgoConfiguration(host=host_url),
+            header_name="Authorization",
+            header_value=f"Bearer {access_token}"))
+
+
+class ArgoArchivedWorkflowsClientMixin:
+    def __init__(self, *args, argo_url, access_token, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.argo_url = argo_url
+        self.access_token = access_token
+        self._client = None
+
+    def client(self):
+        if not self._client:
+            self._client = generate_argo_archived_workflows_client(self.argo_url, self.access_token)
+
+        return self._client
+
+    def list_archived_workflows(self):
+        self._pull_paginated_results(self.client().list_archived_workflows)
+
+    def _pull_paginated_results(self, api_function):
+        results = api_function()
+
+        for result in results.items:
+            yield result
+
+        while results.metadata['_continue']:
+            results = api_function(list_option_continue=results.metadata['_continue'])
+
+            for result in results.items:
+                yield result
+
+
+class ExtendedArgoWorkflow(ArgoArchivedWorkflowsClientMixin):
+    def __init__(self, workflow: V1alpha1Workflow, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._workflow = workflow
+        self._inflated = False
+
+    def inflate(self):
+        if not self._inflated:
+            self._workflow = self.client().get_archived_workflow(self.metadata.uid)
+            self._inflated = True
+
+        return self
+
+    def params_dict(self):
+        return {
+            param.name: param.value
+            for param in self.spec.arguments.parameters
+        }
+
+    def __getattr__(self, name):
+        return getattr(self._workflow, name)
+
+    def __eq__(self, other):
+        return isinstance(other, ExtendedArgoWorkflow) and self._workflow == other._workflow

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/base.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/base.py
@@ -16,8 +16,7 @@ POLLING_INTERVAL = 5  # seconds
 def default_google_access_token():
     # get token for google-based auth use, assumes application default credentials work for specified environment
     credentials, _ = google.auth.default()
-    auth_req = Request()
-    credentials.refresh(auth_req)
+    credentials.refresh(Request())
 
     return credentials.token
 

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/base.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/base.py
@@ -13,6 +13,15 @@ ONE_DAY_IN_SECONDS = 86400  # seconds
 POLLING_INTERVAL = 5  # seconds
 
 
+def default_google_access_token():
+    # get token for google-based auth use, assumes application default credentials work for specified environment
+    credentials, _ = google.auth.default()
+    auth_req = Request()
+    credentials.refresh(auth_req)
+
+    return credentials.token
+
+
 @resource({
     "working_dir": Field(StringSource)
 })
@@ -71,20 +80,20 @@ class DataflowBeamRunner:
             f"--inputPrefix={input_prefix}",
             f"--outputPrefix={output_prefix}",
             f"--project={self.project}",
-            f"--region=us-central1",
+            "--region=us-central1",
             f"--tempLocation={self.temp_location}",
             f"--subnetwork=regions/us-central1/subnetworks/{self.subnet_name}",
             f"--serviceAccount={self.service_account}",
-            f"--workerMachineType=n1-standard-4",
-            f"--autoscalingAlgorithm=THROUGHPUT_BASED",
-            f"--numWorkers=4",
-            f"--maxNumWorkers=16",
-            f"--experiments=shuffle_mode=service"
+            "--workerMachineType=n1-standard-4",
+            "--autoscalingAlgorithm=THROUGHPUT_BASED",
+            "--numWorkers=4",
+            "--maxNumWorkers=16",
+            "--experiments=shuffle_mode=service"
         ]
 
         image_name = f"{self.image_name}:{self.image_version}"  # {context.solid_config['version']}"
         job = self.dispatch_k8s_job(self.namespace, image_name, job_name, args, context)
-        context.log.info(f"Dataflow job started")
+        context.log.info("Dataflow job started")
 
         DataflowBeamRunner.get_job_status(job.metadata.name, self.namespace)
         client = DagsterKubernetesClient.production_client()
@@ -134,7 +143,7 @@ class DataflowBeamRunner:
         api_response = batch_v1.create_namespaced_job(
             body=job,
             namespace=namespace)
-        context.log.info(f"Job created. status='%s'" % str(api_response.status))
+        context.log.info(f"Job created. status='{str(api_response.status)}'")
 
         return api_response
 
@@ -150,14 +159,9 @@ def google_storage_client(init_context):
     "api_url": Field(StringSource)
 })
 def jade_data_repo_client(init_context):
-    # get token for jade, assumes application default credentials work for specified environment
-    credentials, _ = google.auth.default()
-    auth_req = Request()
-    credentials.refresh(auth_req)
-
     # create API client
     config = Configuration(host=init_context.resource_config["api_url"])
-    config.access_token = credentials.token
+    config.access_token = default_google_access_token
     client = ApiClient(configuration=config)
     client.client_side_validation = False
 

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/base.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/base.py
@@ -161,7 +161,7 @@ def google_storage_client(init_context):
 def jade_data_repo_client(init_context):
     # create API client
     config = Configuration(host=init_context.resource_config["api_url"])
-    config.access_token = default_google_access_token
+    config.access_token = default_google_access_token()
     client = ApiClient(configuration=config)
     client.client_side_validation = False
 

--- a/orchestration/dagster_orchestration/hca_orchestration/sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/sensors.py
@@ -1,0 +1,57 @@
+import os
+
+from dagster import sensor, RunRequest, SkipReason
+
+from argo.workflows.client import ApiClient as ArgoApiClient,\
+                                  ArchivedWorkflowServiceApi,\
+                                  Configuration as ArgoConfiguration
+from .resources.base import default_google_access_token
+
+
+# this isn't defined as a resource because resources aren't available to sensors
+def generate_argo_workflows_client(host_url):
+    return ArchivedWorkflowServiceApi(
+        api_client=ArgoApiClient(
+            configuration=ArgoConfiguration(host=host_url),
+            header_name="Authorization",
+            header_value=f"Bearer {default_google_access_token()}"))
+
+
+# TODO use execution context to avoid re-scanning old workflows
+@sensor(pipeline_name="validate_egress")
+def postvalidate_on_import_complete(_):
+    client = generate_argo_workflows_client()
+
+    workflows = [
+        workflow
+        for workflow
+        in client.list_archived_workflows()
+        if workflow.metadata.name.startswith("import-hca-total")
+        and workflow.status.phase == 'Succeeded'
+    ]
+
+    if any(workflows):
+        for workflow in workflows:
+            # the list-workflows endpoint doesn't include parameter metadata, so we need to make a separate get
+            # request to inflate the workflow once we know we want to do something with it.
+            inflated_workflow = client.get_archived_workflow(workflow.metadata.uid)
+            workflow_params = {
+                param.name: param.value
+                for param in inflated_workflow.spec.arguments.parameters
+            }
+
+            yield RunRequest(
+                run_key=inflated_workflow.metadata.name,
+                run_config={
+                    "solids": {
+                        "post_import_validate": {
+                            "config": {
+                                "google_project_name": os.environ.get("HCA_GOOGLE_PROJECT"),
+                                "dataset_name": workflow_params['data-repo-name'].removeprefix("datarepo_"),
+                            }
+                        }
+                    }
+                }
+            )
+    else:
+        return SkipReason("No succeeded import-hca-total workflows returned by Argo.")

--- a/orchestration/dagster_orchestration/hca_orchestration/sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/sensors.py
@@ -46,6 +46,7 @@ def postvalidate_on_import_complete(_):
                     "solids": {
                         "post_import_validate": {
                             "config": {
+                                "gcp_env": os.environ.get("HCA_GCP_ENV"),
                                 "google_project_name": os.environ.get("HCA_GOOGLE_PROJECT"),
                                 "dataset_name": workflow_params['data-repo-name'].removeprefix("datarepo_"),
                             }

--- a/orchestration/dagster_orchestration/hca_orchestration/sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/sensors.py
@@ -1,58 +1,50 @@
 import os
+from typing import List
 
 from dagster import sensor, RunRequest, SkipReason
 
-from argo.workflows.client import ApiClient as ArgoApiClient,\
-                                  ArchivedWorkflowServiceApi,\
-                                  Configuration as ArgoConfiguration
-from .resources.base import default_google_access_token
+from hca_orchestration.contrib.argo_workflows import ArgoArchivedWorkflowsClientMixin, ExtendedArgoWorkflow
+from hca_orchestration.resources.base import default_google_access_token
 
 
-# this isn't defined as a resource because resources aren't available to sensors
-def generate_argo_workflows_client(host_url):
-    return ArchivedWorkflowServiceApi(
-        api_client=ArgoApiClient(
-            configuration=ArgoConfiguration(host=host_url),
-            header_name="Authorization",
-            header_value=f"Bearer {default_google_access_token()}"))
+class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClientMixin):
+    def successful_hca_import_workflows(self) -> List[ExtendedArgoWorkflow]:
+        return [
+            ExtendedArgoWorkflow(workflow, argo_url=self.argo_url, access_token=self.access_token)
+            for workflow
+            in self.list_archived_workflows()
+            if workflow.metadata.name.startswith("import-hca-total")
+            and workflow.status.phase == 'Succeeded'
+        ]
+
+    def generate_run_request(self, workflow: ExtendedArgoWorkflow) -> RunRequest:
+        inflated_workflow = workflow.inflate()
+
+        return RunRequest(
+            run_key=inflated_workflow.metadata.name,
+            run_config={
+                "solids": {
+                    "post_import_validate": {
+                        "config": {
+                            "gcp_env": os.environ.get("HCA_GCP_ENV"),
+                            "google_project_name": os.environ.get("HCA_GOOGLE_PROJECT"),
+                            "dataset_name": inflated_workflow.params_dict()['data-repo-name'].removeprefix("datarepo_"),
+                        }
+                    }
+                }
+            }
+        )
 
 
 # TODO use execution context to avoid re-scanning old workflows
 @sensor(pipeline_name="validate_egress")
 def postvalidate_on_import_complete(_):
-    client = generate_argo_workflows_client()
+    sensor = ArgoHcaImportCompletionSensor(argo_url=os.environ.get("HCA_ARGO_URL"), access_token=default_google_access_token())
 
-    workflows = [
-        workflow
-        for workflow
-        in client.list_archived_workflows()
-        if workflow.metadata.name.startswith("import-hca-total")
-        and workflow.status.phase == 'Succeeded'
-    ]
+    workflows = sensor.successful_hca_import_workflows()
 
     if any(workflows):
         for workflow in workflows:
-            # the list-workflows endpoint doesn't include parameter metadata, so we need to make a separate get
-            # request to inflate the workflow once we know we want to do something with it.
-            inflated_workflow = client.get_archived_workflow(workflow.metadata.uid)
-            workflow_params = {
-                param.name: param.value
-                for param in inflated_workflow.spec.arguments.parameters
-            }
-
-            yield RunRequest(
-                run_key=inflated_workflow.metadata.name,
-                run_config={
-                    "solids": {
-                        "post_import_validate": {
-                            "config": {
-                                "gcp_env": os.environ.get("HCA_GCP_ENV"),
-                                "google_project_name": os.environ.get("HCA_GOOGLE_PROJECT"),
-                                "dataset_name": workflow_params['data-repo-name'].removeprefix("datarepo_"),
-                            }
-                        }
-                    }
-                }
-            )
+            yield sensor.generate_run_request(workflow)
     else:
         return SkipReason("No succeeded import-hca-total workflows returned by Argo.")

--- a/orchestration/dagster_orchestration/hca_orchestration/sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/sensors.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 from typing import List
 
@@ -5,6 +6,10 @@ from dagster import sensor, RunRequest, SkipReason
 
 from hca_orchestration.contrib.argo_workflows import ArgoArchivedWorkflowsClientMixin, ExtendedArgoWorkflow
 from hca_orchestration.resources.base import default_google_access_token
+
+
+# boundary before which we don't care about any workflows in argo
+ARGO_EPOCH = datetime(2021, 3, 1)
 
 
 class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClientMixin):
@@ -15,6 +20,7 @@ class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClientMixin):
             in self.list_archived_workflows()
             if workflow.metadata.name.startswith("import-hca-total")
             and workflow.status.phase == 'Succeeded'
+            and workflow.status.finished_at > ARGO_EPOCH
         ]
 
     def generate_run_request(self, workflow: ExtendedArgoWorkflow) -> RunRequest:

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import patch
+
+from argo.workflows.client import ArchivedWorkflowServiceApi
+from argo.workflows.client.models import V1alpha1Arguments, V1alpha1Parameter, V1alpha1Workflow, V1alpha1WorkflowSpec,\
+    V1alpha1WorkflowStatus, V1ObjectMeta
+
+from hca_orchestration.contrib.argo_workflows import ExtendedArgoWorkflow, generate_argo_archived_workflows_client
+from hca_orchestration.sensors import ArgoHcaImportCompletionSensor
+
+
+# helper to turn a list into a generator to help mock generator functions
+def generator(iterable):
+    for obj in iterable:
+        yield obj
+
+
+# the argo workflows api produces this abominable nested set of classes for each workflow,
+# so we build one from simple params here to keep our tests lean
+def mock_argo_workflow(name, uid, status, params={}):
+    return V1alpha1Workflow(
+        metadata=V1ObjectMeta(
+            name=name,
+            uid=uid,
+        ),
+        spec=V1alpha1WorkflowSpec(
+            arguments=V1alpha1Arguments(
+                parameters=[
+                    V1alpha1Parameter(name=k, value=v)
+                    for k, v in params.items()
+                ]
+            )
+        ),
+        status=V1alpha1WorkflowStatus(
+            phase=status
+        )
+    )
+
+
+def extend_workflow(workflow: V1alpha1Workflow) -> ExtendedArgoWorkflow:
+    return ExtendedArgoWorkflow(workflow, argo_url='https://nonexistentsite.test', access_token='token')
+
+
+class TestArgoWorkflowsClient(unittest.TestCase):
+    def test_generates_a_client_with_the_specified_parameters(self):
+        client = generate_argo_archived_workflows_client("https://zombo.com", "tokentokentoken")
+
+        self.assertIsInstance(client, ArchivedWorkflowServiceApi)
+        self.assertIn("Authorization", client.api_client.default_headers)
+        self.assertEqual(client.api_client.default_headers['Authorization'], "Bearer tokentokentoken")
+        self.assertEqual(client.api_client.configuration.host, "https://zombo.com")
+
+
+class TestArgoHcaImportCompletionSensor(unittest.TestCase):
+    def test_successful_hca_import_workflows_only_includes_import_workflows(self):
+        archived_workflows = [
+            mock_argo_workflow('abc-not-an-import', 'abc123uid', 'Succeeded'),
+            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Succeeded', {
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+            mock_argo_workflow('import-hca-total-cdef', 'abc345uid', 'Succeeded', {
+                'data-repo-name': 'datarepo_dataset2'
+            }),
+        ]
+
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows', return_value=generator(archived_workflows)):
+            workflows = list(ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token').successful_hca_import_workflows())
+
+            self.assertNotIn(extend_workflow(archived_workflows[0]), workflows)
+            self.assertIn(extend_workflow(archived_workflows[1]), workflows)
+            self.assertIn(extend_workflow(archived_workflows[2]), workflows)
+
+    def test_successful_hca_import_workflows_only_includes_succeeded_workflows(self):
+        archived_workflows = [
+            mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
+            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', {
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+            mock_argo_workflow('import-hca-total-cdef', 'abc345uid', 'Succeeded', {
+                'data-repo-name': 'datarepo_dataset2'
+            }),
+        ]
+
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows', return_value=generator(archived_workflows)):
+            workflows = list(ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token').successful_hca_import_workflows())
+
+            self.assertIn(extend_workflow(archived_workflows[0]), workflows)
+            self.assertNotIn(extend_workflow(archived_workflows[1]), workflows)
+            self.assertIn(extend_workflow(archived_workflows[2]), workflows)
+
+    def test_generate_run_request_uses_workflow_name_for_run_key(self):
+        sensor = ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token')
+        workflow = extend_workflow(mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded', {'data-repo-name': 'datarepo_snatasnet'}))
+        with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate', return_value=workflow):
+            req = sensor.generate_run_request(workflow)
+
+            self.assertEqual(req.run_key, 'import-hca-total-defg')
+
+    def test_generate_run_request_inflates_workflow(self):
+        sensor = ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token')
+        workflow = extend_workflow(mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded', {'data-repo-name': 'datarepo_snatasnet'}))
+        with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate', return_value=workflow) as mocked_inflate:
+            sensor.generate_run_request(workflow)
+            mocked_inflate.assert_called_once()
+
+    def test_generate_run_request_provides_correct_pipeline_params(self):
+        sensor = ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token')
+        workflow = extend_workflow(mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded', {'data-repo-name': 'datarepo_snatasnet'}))
+        with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate', return_value=workflow):
+            req = sensor.generate_run_request(workflow)
+            self.assertEqual(req.run_config['solids']['post_import_validate']['config']['dataset_name'], 'snatasnet')

--- a/orchestration/dagster_orchestration/hca_utils/main.py
+++ b/orchestration/dagster_orchestration/hca_utils/main.py
@@ -7,6 +7,7 @@ from google.auth.transport.requests import Request
 
 from hca_utils import __version__ as hca_utils_version
 from .utils import HcaUtils
+from hca_orchestration.base import default_google_access_token
 
 
 class DefaultHelpParser(argparse.ArgumentParser):
@@ -18,13 +19,10 @@ class DefaultHelpParser(argparse.ArgumentParser):
 
 
 def get_api_client(host: str) -> RepositoryApi:
-    # get token for jade, assumes application default credentials work for specified environment
-    credentials, _ = google.auth.default()
-    credentials.refresh(Request())
 
     # create API client
     config = Configuration(host=host)
-    config.access_token = credentials.token
+    config.access_token = default_google_access_token()
     client = ApiClient(configuration=config)
     client.client_side_validation = False
 

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -12,6 +12,7 @@ google-cloud-bigquery = "^2.4.0"
 google-cloud-storage = "^1.3.5"
 dagster-k8s = "^0.10.5"
 data-repo-client = "^1.0.194.post5"
+argo-workflows = "^5.0.0"
 
 [tool.poetry.dev-dependencies]
 pdbpp = "^0.10.2"


### PR DESCRIPTION
* Adds a sensor that periodically scans through archived (i.e. completed) workflows in the target Argo instance, triggering the  egress validation pipeline for any completed HCA import workflows
* Introduces env-level environment variable config to our Dagster instances via our Helm chart.
* Adds a helper to generate an Argo workflows API client, but doesn't add it as a resource, since sensors can't access resources