### PR TITLE
Add linting and unit testing job to CI for Dagster code

### DIFF
--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -23,7 +23,10 @@ jobs:
       uses: snok/install-poetry@v1.1.1
     - name: Install dependencies
       run: poetry install
-      working-directory: {{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+      working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+    - name: Run linter
+      run: flake8
+      working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
     - name: Run Python tests
       run: poetry run pytest
-      working-directory: {{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+      working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -38,9 +38,12 @@ jobs:
     - name: Enforce coding style guide
       run: poetry run flake8
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
+      if: true
     - name: Check static types
       run: poetry run mypy
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
+      if: true
     - name: Run test suite
       run: poetry run pytest
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
+      if: true

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  python-lint:
+  python-validation:
     runs-on: ubuntu-latest
     env:
       ENV: test
@@ -21,6 +21,8 @@ jobs:
         python-version: 3.9
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
+    - name: test
+      run: which poetry
     - name: Install dependencies
       run: poetry install
       working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -23,5 +23,7 @@ jobs:
       uses: snok/install-poetry@v1.1.1
     - name: Install dependencies
       run: poetry install
-    - name: Test
-      run: ./test.sh
+      working-directory: {{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+    - name: Run Python tests
+      run: poetry run pytest
+      working-directory: {{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -21,20 +21,17 @@ jobs:
         python-version: 3.9
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
-    # - name: Cache dependencies
-    #   uses: actions/cache@v2
-    #   env:
-    #     cache-name: cache-poetry
-    #   with:
-    #     # npm cache files are stored in `~/.npm` on Linux/macOS
-    #     path: ~/.npm
-    #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-build-${{ env.cache-name }}-
-    #       ${{ runner.os }}-build-
-    #       ${{ runner.os }}-
-    - name: reveal your secrets
-      run: poetry config --list
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-poetry
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('${{ github.workspace }}/orchestration/dagster_orchestration/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
     - name: Install dependencies
       run: poetry install
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -21,11 +21,25 @@ jobs:
         python-version: 3.9
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
+    # - name: Cache dependencies
+    #   uses: actions/cache@v2
+    #   env:
+    #     cache-name: cache-poetry
+    #   with:
+    #     # npm cache files are stored in `~/.npm` on Linux/macOS
+    #     path: ~/.npm
+    #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-build-${{ env.cache-name }}-
+    #       ${{ runner.os }}-build-
+    #       ${{ runner.os }}-
+    - name: reveal your secrets
+      run: poetry config --list
     - name: Install dependencies
       run: poetry install
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
     - name: Run linter
-      run: flake8
+      run: poetry run flake8
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
     - name: Run Python tests
       run: poetry run pytest

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -1,0 +1,27 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Validate Python
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  python-lint:
+    runs-on: ubuntu-latest
+    env:
+      ENV: test
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Poetry
+      uses: snok/install-poetry@v1.1.1
+    - name: Install dependencies
+      run: poetry install
+    - name: Test
+      run: ./test.sh

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -21,8 +21,6 @@ jobs:
         python-version: 3.9
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
-    - name: test
-      run: echo "${{ github.workspace }}/orchestration/dagster_orchestration"
     - name: Install dependencies
       run: poetry install
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -35,9 +35,12 @@ jobs:
     - name: Install dependencies
       run: poetry install
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-    - name: Run linter
+    - name: Enforce coding style guide
       run: poetry run flake8
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-    - name: Run Python tests
+    - name: Check static types
+      run: poetry run mypy
+      working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
+    - name: Run test suite
       run: poetry run pytest
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -33,17 +33,18 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Install dependencies
+      id: dependencies
       run: poetry install
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
     - name: Enforce coding style guide
       run: poetry run flake8
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-      if: true
+      if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails
     - name: Check static types
       run: poetry run mypy
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-      if: true
+      if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails
     - name: Run test suite
       run: poetry run pytest
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-      if: true
+      if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
     - name: test
-      run: which poetry
+      run: echo "${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration"
     - name: Install dependencies
       run: poetry install
       working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -22,13 +22,13 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
     - name: test
-      run: echo "${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration"
+      run: echo "${{ github.workspace }}/orchestration/dagster_orchestration"
     - name: Install dependencies
       run: poetry install
-      working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+      working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
     - name: Run linter
       run: flake8
-      working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+      working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
     - name: Run Python tests
       run: poetry run pytest
-      working-directory: ${{ env.GITHUB_WORKSPACE }}/orchestration/dagster_orchestration
+      working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration

--- a/orchestration/dagster_orchestration/.pre-commit-config.yaml
+++ b/orchestration/dagster_orchestration/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-autopep8
-  rev: master
+  rev: v1.5.4
   hooks:
   - id: autopep8

--- a/orchestration/dagster_orchestration/.pre-commit-config.yaml
+++ b/orchestration/dagster_orchestration/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-autopep8
+  rev: master
+  hooks:
+  - id: autopep8

--- a/orchestration/dagster_orchestration/README.md
+++ b/orchestration/dagster_orchestration/README.md
@@ -4,9 +4,15 @@ This is an initial introduction of [Dagster](https://dagster.io)
 into our codebase for workflow orchestration. This document captures notes,
 todos and anything else we bump into as we test out this technology.
 
+## Setting up your dev environment
+* Make sure you have [Poetry](https://python-poetry.org/docs/#installation) installed.
+* From the `dagster_orchestration` dir, run `poetry install` to install all dependencies.
+* Run `poetry run pre-commit install` to install a hook that will automatically lint your code whenever you create a commit.
+	* If the hook blocks you from creating a commit, you can just run `git commit` again, unless it reports any linting errors it wasn't able to fix.
+
 ## Running
-We're using poetry:
-* from the `dagster` dir, run `poetry install`
+Once you have your environment set up:
+
 * Run dagit and our toy pipeline via `poetry run dagit  -f hca_orchestration/pipelines.py`
 
 The `stage_data` pipeline is being built to mimic our current HCA `stage_data` pipeline.

--- a/orchestration/dagster_orchestration/hca_manage/main.py
+++ b/orchestration/dagster_orchestration/hca_manage/main.py
@@ -34,7 +34,7 @@ def get_api_client(host: str) -> RepositoryApi:
 
     return RepositoryApi(api_client=client)
 
-# longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
 def run(arguments=None):
     parser = DefaultHelpParser(description="A simple HCA Management CLI.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)

--- a/orchestration/dagster_orchestration/hca_manage/main.py
+++ b/orchestration/dagster_orchestration/hca_manage/main.py
@@ -34,7 +34,7 @@ def get_api_client(host: str) -> RepositoryApi:
 
     return RepositoryApi(api_client=client)
 
-
+# longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 def run(arguments=None):
     parser = DefaultHelpParser(description="A simple HCA Management CLI.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)

--- a/orchestration/dagster_orchestration/hca_manage/main.py
+++ b/orchestration/dagster_orchestration/hca_manage/main.py
@@ -49,7 +49,8 @@ def run(arguments=None):
     parser_check.add_argument("-p", "--project", help="The Jade project to target, defaults to correct project for dev")
     parser_check.add_argument("-d", "--dataset", help="The Jade dataset to target", required=True)
     parser_check.add_argument("-r", "--remove",
-                              help="Remove problematic rows. If flag not set, will only check for presence of problematic rows",
+                              help="Remove problematic rows. If flag not set, "
+                                   "will only check for presence of problematic rows",
                               action="store_true")
 
     # snapshot management

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -39,11 +39,15 @@ class HcaManage:
         jade_urls = {"prod": "https://jade-terra.datarepo-prod.broadinstitute.org",
                      "dev": "https://jade.datarepo-dev.broadinstitute.org"}
         self.base_url = jade_urls[environment]
+        self._gcp_creds = None
 
+    def gcp_creds(self):
         # use application default credentials to seamlessly work across monster devs
         # assumes `gcloud auth application-default login` has been run
-        creds, _ = google.auth.default()
-        self.gcp_creds = creds
+        if not self._gcp_creds:
+            self._gcp_creds, _ = google.auth.default()
+
+        return self._gcp_creds
 
         self.reader_list = {
             "dev": ["hca-snapshot-readers@dev.test.firecloud.org"],

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -39,6 +39,12 @@ class HcaManage:
         jade_urls = {"prod": "https://jade-terra.datarepo-prod.broadinstitute.org",
                      "dev": "https://jade.datarepo-dev.broadinstitute.org"}
         self.base_url = jade_urls[environment]
+
+        self.reader_list = {
+            "dev": ["hca-snapshot-readers@dev.test.firecloud.org"],
+            "prod": ["hca-snapshot-readers@firecloud.org"]
+        }[environment]
+
         self._gcp_creds = None
 
     def gcp_creds(self):
@@ -48,11 +54,6 @@ class HcaManage:
             self._gcp_creds, _ = google.auth.default()
 
         return self._gcp_creds
-
-        self.reader_list = {
-            "dev": ["hca-snapshot-readers@dev.test.firecloud.org"],
-            "prod": ["hca-snapshot-readers@firecloud.org"]
-        }[environment]
 
     # lazy initializer
     def bigquery_client(self) -> bigquery.client.Client:
@@ -161,7 +162,7 @@ class HcaManage:
 
         return self._hit_bigquery(query)
 
-    def _hit_bigquery(self, query):
+    def _hit_bigquery(self, query: str) -> Set[str]:
         """
         Helper function to consistently interact with biqquery while reusing the same client.
         :param query: The SQL query to run.
@@ -213,7 +214,7 @@ class HcaManage:
         """
 
         response = self.data_repo_client.enumerate_datasets(filter=self.dataset)
-        return response.items[0].id
+        return response.items[0].id  # type: ignore # data repo client has no type hints, since it's auto-generated
 
     def submit_soft_delete(self, target_table: str, target_path: str) -> str:
         """
@@ -238,7 +239,7 @@ class HcaManage:
                     }
                 ]))
 
-        return response.id
+        return response.id  # type: ignore # data repo client has no type hints, since it's auto-generated
 
     def submit_snapshot_request(self, qualifier: Optional[str] = None) -> str:
         date_stamp = str(datetime.today().date()).replace("-", "")
@@ -262,7 +263,7 @@ class HcaManage:
         )
 
         logging.info(f"Snapshot creation job id: {response.id}")
-        return response.id
+        return response.id  # type: ignore # data repo client has no type hints, since it's auto-generated
 
     def delete_snapshot(self, snapshot_name: Optional[str] = None, snapshot_id: Optional[str] = None):
         if snapshot_name and not snapshot_id:
@@ -292,9 +293,9 @@ class HcaManage:
         else:
             # can't have both/neither provided
             raise ValueError("You must provide either dataset_name or dataset_id, and cannot provide neither/both.")
-        response = self.data_repo_client.delete_dataset(dataset_id)
-        logging.info(f"Dataset deletion job id: {response.id}")
-        return response.id
+        delete_response = self.data_repo_client.delete_dataset(dataset_id)
+        logging.info(f"Dataset deletion job id: {delete_response.id}")
+        return delete_response.id
 
     # dataset-level checking and soft deleting
     def process_duplicates(self, soft_delete: bool = False):

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -51,7 +51,7 @@ class HcaManage:
         }[environment]
 
     # lazy initializer
-    def bigquery_client(self) -> bigquery.Client:
+    def bigquery_client(self) -> bigquery.client.Client:
         if not self._bigquery_client:
             self._bigquery_client = bigquery.Client(project=self.project)
 

--- a/orchestration/dagster_orchestration/hca_orchestration/__init__.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/__init__.py
@@ -1,1 +1,0 @@
-from dagster import repository

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
@@ -17,11 +17,14 @@ def generate_argo_archived_workflows_client(host_url: str, access_token: str) ->
             header_value=f"Bearer {access_token}"))
 
 
+# protocols let us set up complex type constraints on function arguments.
+# this is a useful alternative when referencing functions from third-party libraries that aren't
+# properly type annotated.
 class ArgoFetchListOperation(Protocol):
     def __call__(
         self,
         *args: Any,
-        list_option_continue: Optional[str] = None,
+        list_options_continue: Optional[str] = None,
         **kwargs: Any
     ) -> V1alpha1WorkflowList: ...
 

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/argo_workflows.py
@@ -32,7 +32,11 @@ class ArgoArchivedWorkflowsClientMixin:
     def list_archived_workflows(self) -> Generator[V1alpha1Workflow, None, None]:
         return self._pull_paginated_results(self.client().list_archived_workflows)
 
-    def _pull_paginated_results(self, api_function: Callable[[Optional[str]], V1alpha1WorkflowList]) -> Generator[V1alpha1Workflow, None, None]:
+    def _pull_paginated_results(self,
+                                api_function: Callable[
+                                    [Optional[str]],
+                                    V1alpha1WorkflowList
+                                ]) -> Generator[V1alpha1Workflow, None, None]:
         results = api_function()
 
         for result in results.items:

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/test.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/test.py
@@ -21,7 +21,7 @@ def local_storage_client(init_context):
             pass
 
     class LocalStorageClient:
-        def list_blobs(self, bucket_name, prefix):
+        def list_blobs(self, bucket_name: str, prefix: str):
             for _ in range(0, 10):
                 yield MockBlob()
 

--- a/orchestration/dagster_orchestration/hca_orchestration/sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/sensors.py
@@ -6,15 +6,15 @@ from dateutil.tz import tzlocal
 
 from dagster import sensor, RunRequest, SkipReason
 
-from hca_orchestration.contrib.argo_workflows import ArgoArchivedWorkflowsClientMixin, ExtendedArgoWorkflow
+from hca_orchestration.contrib.argo_workflows import ArgoArchivedWorkflowsClient, ExtendedArgoWorkflow
 from hca_orchestration.resources.base import default_google_access_token
 
 
 # boundary before which we don't care about any workflows in argo
-ARGO_EPOCH = datetime(2021, 3, 15, tzinfo=tzlocal())
+ARGO_EPOCH: datetime = datetime(2021, 3, 15, tzinfo=tzlocal())
 
 
-class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClientMixin):
+class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClient):
     def successful_hca_import_workflows(self) -> List[ExtendedArgoWorkflow]:
         return [
             ExtendedArgoWorkflow(workflow, argo_url=self.argo_url, access_token=self.access_token)

--- a/orchestration/dagster_orchestration/hca_orchestration/sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/sensors.py
@@ -36,7 +36,8 @@ class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClientMixin):
                         "config": {
                             "gcp_env": os.environ.get("HCA_GCP_ENV"),
                             "google_project_name": os.environ.get("HCA_GOOGLE_PROJECT"),
-                            "dataset_name": inflated_workflow.params_dict()['data-repo-name'].removeprefix("datarepo_"),
+                            "dataset_name": inflated_workflow.params_dict()['data-repo-name']
+                                                             .removeprefix("datarepo_"),
                         }
                     }
                 },
@@ -54,7 +55,9 @@ class ArgoHcaImportCompletionSensor(ArgoArchivedWorkflowsClientMixin):
 # TODO use execution context to avoid re-scanning old workflows
 @sensor(pipeline_name="validate_egress", mode="prod")
 def postvalidate_on_import_complete(_):
-    sensor = ArgoHcaImportCompletionSensor(argo_url=os.environ.get("HCA_ARGO_URL"), access_token=default_google_access_token())
+    sensor = ArgoHcaImportCompletionSensor(
+        argo_url=os.environ.get("HCA_ARGO_URL"),
+        access_token=default_google_access_token())
 
     workflows = sensor.successful_hca_import_workflows()
 

--- a/orchestration/dagster_orchestration/hca_orchestration/solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids.py
@@ -4,7 +4,8 @@ from hca_manage.manage import HcaManage, ProblemCount
 DagsterProblemCount = DagsterType(
     name="DagsterProblemCount",
     type_check_fn=lambda _, value: isinstance(value, ProblemCount),
-    description="A simple named tuple to represent the different types of issues present from the post process validation.",
+    description="A simple named tuple to represent the different types of issues "
+                "present from the post process validation.",
 )
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids.py
@@ -1,7 +1,7 @@
 from dagster import solid, InputDefinition, Nothing, String, DagsterType
 from hca_manage.manage import HcaManage, ProblemCount
 
-DagsterProblemCount = DagsterType(
+DagsterProblemCount: DagsterType = DagsterType(
     name="DagsterProblemCount",
     type_check_fn=lambda _, value: isinstance(value, ProblemCount),
     description="A simple named tuple to represent the different types of issues "

--- a/orchestration/dagster_orchestration/hca_orchestration/solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids.py
@@ -1,9 +1,17 @@
 from dagster import solid, InputDefinition, Nothing, String, DagsterType
+
 from hca_manage.manage import HcaManage, ProblemCount
+
+from typing import Any
+
+
+def problem_count_typecheck(_, value: Any) -> bool:
+    return isinstance(value, ProblemCount)
+
 
 DagsterProblemCount: DagsterType = DagsterType(
     name="DagsterProblemCount",
-    type_check_fn=lambda _, value: isinstance(value, ProblemCount),
+    type_check_fn=problem_count_typecheck,
     description="A simple named tuple to represent the different types of issues "
                 "present from the post process validation.",
 )

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
@@ -71,7 +71,7 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
             }),
         ]
 
-        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows',
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClient.list_archived_workflows',
                    return_value=generator(archived_workflows)):
             workflows = list(
                 ArgoHcaImportCompletionSensor(
@@ -95,7 +95,7 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
             }),
         ]
 
-        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows',
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClient.list_archived_workflows',
                    return_value=generator(archived_workflows)):
             workflows = list(
                 ArgoHcaImportCompletionSensor(
@@ -121,7 +121,7 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
             }),
         ]
 
-        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows',
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClient.list_archived_workflows',
                    return_value=generator(archived_workflows)):
             workflows = list(
                 ArgoHcaImportCompletionSensor(

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
@@ -71,8 +71,14 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
             }),
         ]
 
-        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows', return_value=generator(archived_workflows)):
-            workflows = list(ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token').successful_hca_import_workflows())
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows',
+                   return_value=generator(archived_workflows)):
+            workflows = list(
+                ArgoHcaImportCompletionSensor(
+                    argo_url='https://nonexistentsite.test',
+                    access_token='token'
+                ).successful_hca_import_workflows()
+            )
 
             self.assertNotIn(extend_workflow(archived_workflows[0]), workflows)
             self.assertIn(extend_workflow(archived_workflows[1]), workflows)
@@ -89,8 +95,14 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
             }),
         ]
 
-        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows', return_value=generator(archived_workflows)):
-            workflows = list(ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token').successful_hca_import_workflows())
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows',
+                   return_value=generator(archived_workflows)):
+            workflows = list(
+                ArgoHcaImportCompletionSensor(
+                    argo_url='https://nonexistentsite.test',
+                    access_token='token'
+                ).successful_hca_import_workflows()
+            )
 
             self.assertIn(extend_workflow(archived_workflows[0]), workflows)
             self.assertNotIn(extend_workflow(archived_workflows[1]), workflows)
@@ -109,8 +121,14 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
             }),
         ]
 
-        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows', return_value=generator(archived_workflows)):
-            workflows = list(ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token').successful_hca_import_workflows())
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClientMixin.list_archived_workflows',
+                   return_value=generator(archived_workflows)):
+            workflows = list(
+                ArgoHcaImportCompletionSensor(
+                    argo_url='https://nonexistentsite.test',
+                    access_token='token'
+                ).successful_hca_import_workflows()
+            )
 
             self.assertIn(extend_workflow(archived_workflows[0]), workflows)
             self.assertIn(extend_workflow(archived_workflows[1]), workflows)
@@ -118,7 +136,12 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
 
     def test_generate_run_request_uses_workflow_name_for_run_key(self):
         sensor = ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token')
-        workflow = extend_workflow(mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded', params={'data-repo-name': 'datarepo_snatasnet'}))
+        workflow = extend_workflow(mock_argo_workflow(
+            'import-hca-total-defg',
+            'abc123uid',
+            'Succeeded',
+            params={'data-repo-name': 'datarepo_snatasnet'}
+        ))
         with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate', return_value=workflow):
             req = sensor.generate_run_request(workflow)
 
@@ -126,14 +149,25 @@ class TestArgoHcaImportCompletionSensor(unittest.TestCase):
 
     def test_generate_run_request_inflates_workflow(self):
         sensor = ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token')
-        workflow = extend_workflow(mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded', params={'data-repo-name': 'datarepo_snatasnet'}))
-        with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate', return_value=workflow) as mocked_inflate:
+        workflow = extend_workflow(mock_argo_workflow(
+            'import-hca-total-defg',
+            'abc123uid',
+            'Succeeded',
+            params={'data-repo-name': 'datarepo_snatasnet'}
+        ))
+        with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate',
+                   return_value=workflow) as mocked_inflate:
             sensor.generate_run_request(workflow)
             mocked_inflate.assert_called_once()
 
     def test_generate_run_request_provides_correct_pipeline_params(self):
         sensor = ArgoHcaImportCompletionSensor(argo_url='https://nonexistentsite.test', access_token='token')
-        workflow = extend_workflow(mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded', params={'data-repo-name': 'datarepo_snatasnet'}))
+        workflow = extend_workflow(mock_argo_workflow(
+            'import-hca-total-defg',
+            'abc123uid',
+            'Succeeded',
+            params={'data-repo-name': 'datarepo_snatasnet'}
+        ))
         with patch('hca_orchestration.contrib.argo_workflows.ExtendedArgoWorkflow.inflate', return_value=workflow):
             req = sensor.generate_run_request(workflow)
             self.assertEqual(req.run_config['solids']['post_import_validate']['config']['dataset_name'], 'snatasnet')

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_solids.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from dagster import execute_solid
 
+from hca_orchestration.resources.modes import test_mode
 from hca_orchestration.solids import post_import_validate
 
 
@@ -39,7 +40,7 @@ class SolidsTestCase(unittest.TestCase):
             }
         }
 
-        result = execute_solid(post_import_validate, run_config=solid_config)
+        result = execute_solid(post_import_validate, run_config=solid_config, mode_def=test_mode)
         self.assertTrue(result.success)
         expected_duplicate_issues = len(fake_table_names) * len(fake_duplicate_ids)
         expected_file_ref_issues = len(fake_file_table_names) * len(fake_null_fileref_ids)

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_solids.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 from dagster import execute_solid
 
-from hca_orchestration.resources.modes import test_mode
+from hca_orchestration.pipelines.validate_egress import test_mode
 from hca_orchestration.solids import post_import_validate
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_solids.py
@@ -8,10 +8,10 @@ from hca_orchestration.solids import post_import_validate
 
 
 class SolidsTestCase(unittest.TestCase):
-    @patch("hca_manage.manage.HcaManage.get_null_filerefs")
-    @patch("hca_manage.manage.HcaManage.get_file_table_names")
-    @patch("hca_manage.manage.HcaManage.get_duplicates")
-    @patch("hca_manage.manage.HcaManage.get_all_table_names")
+    @patch("hca_manage.manage.HcaManage.get_null_filerefs", return_value=set())
+    @patch("hca_manage.manage.HcaManage.get_file_table_names", return_value=set())
+    @patch("hca_manage.manage.HcaManage.get_duplicates", return_value=set())
+    @patch("hca_manage.manage.HcaManage.get_all_table_names", return_value=set())
     def test_post_import_validate(self, mock_all_table_names: Mock, mock_duplicates: Mock, mock_file_table_names: Mock,
                                   mock_null_filerefs: Mock):
         """

--- a/orchestration/dagster_orchestration/mypy.ini
+++ b/orchestration/dagster_orchestration/mypy.ini
@@ -1,14 +1,13 @@
 # Configuration for static type checking
 [mypy]
-files = hca_orchestration
-mypy_path = hca_orchestration/stubs
+files = hca_orchestration,hca_manage
+mypy_path = ~/Code/hca-ingest/orchestration/dagster_orchestration/stubs
 
 # warn if a function with an explicit return type returns a value with type Any
 warn_return_any = True
+
 # no generic types with "Any" as a parameter
 disallow_any_generics = True
-# every single expression must be type checked or explicitly marked as skippable ("# type: ignore")
-disallow_any_expr = True
 
 # check to see if there are type hints or stubs for any third party package you use.
 # if there aren't any, add a section for it here so mypy doesn't yell at us about it
@@ -22,7 +21,7 @@ ignore_missing_imports = True
 [mypy-dagster_k8s.*]
 ignore_missing_imports = True
 
-[mypy-data_repo_client]
+[mypy-data_repo_client.*]
 ignore_missing_imports = True
 
 [mypy-google.*]

--- a/orchestration/dagster_orchestration/mypy.ini
+++ b/orchestration/dagster_orchestration/mypy.ini
@@ -1,0 +1,27 @@
+[mypy]
+files = hca_orchestration
+# warn if a function with an explicit return type returns a value with type Any
+warn_return_any = True
+# no generic types with "Any" as a parameter
+disallow_any_generics = True
+
+# check to see if there are type hints or stubs for any third party package you use.
+# if there aren't any, add a section for it here so mypy doesn't yell at us about it
+# not being type hinted.
+[mypy-argo.*]
+ignore_missing_imports = True
+
+[mypy-dagster.*]
+ignore_missing_imports = True
+
+[mypy-dagster_k8s.*]
+ignore_missing_imports = True
+
+[mypy-data_repo_client]
+ignore_missing_imports = True
+
+[mypy-google.*]
+ignore_missing_imports = True
+
+[mypy-kubernetes]
+ignore_missing_imports = True

--- a/orchestration/dagster_orchestration/mypy.ini
+++ b/orchestration/dagster_orchestration/mypy.ini
@@ -1,9 +1,14 @@
+# Configuration for static type checking
 [mypy]
 files = hca_orchestration
+mypy_path = hca_orchestration/stubs
+
 # warn if a function with an explicit return type returns a value with type Any
 warn_return_any = True
 # no generic types with "Any" as a parameter
 disallow_any_generics = True
+# every single expression must be type checked or explicitly marked as skippable ("# type: ignore")
+disallow_any_expr = True
 
 # check to see if there are type hints or stubs for any third party package you use.
 # if there aren't any, add a section for it here so mypy doesn't yell at us about it

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -22,6 +22,7 @@ dagit = "^0.10.5"
 flake8 = "^3.8.4"
 autopep8 = "^1.5.5"
 pre-commit = "^2.11.0"
+mypy = "^0.812"
 
 [tool.poetry.scripts]
 manage = "hca_manage.main:run"

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -20,6 +20,8 @@ pdbpp = "^0.10.2"
 pytest = "^6.2.1"
 dagit = "^0.10.5"
 flake8 = "^3.8.4"
+autopep8 = "^1.5.5"
+pre-commit = "^2.11.0"
 
 [tool.poetry.scripts]
 manage = "hca_manage.main:run"

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -19,6 +19,7 @@ python-dateutil = "^2.8.1"
 pdbpp = "^0.10.2"
 pytest = "^6.2.1"
 dagit = "^0.10.5"
+flake8 = "^3.8.4"
 
 [tool.poetry.scripts]
 manage = "hca_manage.main:run"

--- a/orchestration/dagster_orchestration/pytest.ini
+++ b/orchestration/dagster_orchestration/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+ENV=test

--- a/orchestration/dagster_orchestration/tox.ini
+++ b/orchestration/dagster_orchestration/tox.ini
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .pytest_cache,__pycache__
+max_line_length = 120


### PR DESCRIPTION
New features:
* Adds a Github action to automatically evaluate our Python code for Dagster
  * Runs our test suite automatically via Pytest
  * Lint-checks our code according to the PEP8 style guide
  * Evaluates our code's type hints to ensure they all match up (and all of our first-party code has hints).
* Adds a pre-commit hook to automatically lint Python code as it's committed.