### PR TITLE
Ra dspdc 1583 delete data

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/README.md
+++ b/orchestration/dagster_orchestration/hca_manage/README.md
@@ -18,5 +18,8 @@ To actually remove things, add the remove `-r` flag after:
 
 Be very sure and careful when adding the remove flag.
 
-For snapshot creation:
-`poetry run manage -e dev snapshot -d hca_dev_20201203 -q mytest1`
+Example of snapshot creation:
+`poetry run manage -e dev snapshot -c -d hca_dev_20201203 -q mytest1`
+
+Example of dataset removal:
+`poetry run manage - dev dataset -r -n myfakedataset`

--- a/orchestration/dagster_orchestration/hca_manage/main.py
+++ b/orchestration/dagster_orchestration/hca_manage/main.py
@@ -42,6 +42,7 @@ def run(arguments=None):
                         required=True)
     subparsers = parser.add_subparsers(dest='command')
 
+    # validation checks
     parser_check = subparsers.add_parser("check",
                                          help="Command to check HCA datasets for duplicates and null file references")
     # only allow if env is prod
@@ -51,6 +52,7 @@ def run(arguments=None):
                               help="Remove problematic rows. If flag not set, will only check for presence of problematic rows",
                               action="store_true")
 
+    # snapshot management
     parser_snapshot = subparsers.add_parser("snapshot", help="Command to manage snapshots")
     snapshot_flags = parser_snapshot.add_mutually_exclusive_group(required=True)
     snapshot_flags.add_argument("-c", "--create", help="Flag to indicate snapshot creation", action="store_true")
@@ -62,6 +64,7 @@ def run(arguments=None):
     snapshot_create_args.add_argument("-d", "--dataset", help="The Jade dataset to target")
     snapshot_create_args.add_argument("-q", "--qualifier", help="Optional qualifier to append to the snapshot name")
 
+    # dataset management
     parser_dataset = subparsers.add_parser("dataset", help="Command to manage datasets")
     dataset_flags = parser_dataset.add_mutually_exclusive_group(required=True)
     dataset_flags.add_argument("-r", "--remove", help="Flag to indicate dataset deletion", action="store_true")

--- a/orchestration/dagster_orchestration/hca_manage/main.py
+++ b/orchestration/dagster_orchestration/hca_manage/main.py
@@ -59,7 +59,7 @@ def run(arguments=None):
     snapshot_delete_args.add_argument("-n", "--snapshot_name", help="Name of snapshot to delete.")
     snapshot_delete_args.add_argument("-i", "--snapshot_id", help="ID of snapshot to delete.")
     snapshot_create_args = parser_snapshot.add_argument_group()
-    snapshot_create_args.add_argument("-d", "--dataset", help="The Jade dataset to target", required=True)
+    snapshot_create_args.add_argument("-d", "--dataset", help="The Jade dataset to target")
     snapshot_create_args.add_argument("-q", "--qualifier", help="Optional qualifier to append to the snapshot name")
 
     parser_dataset = subparsers.add_parser("dataset", help="Command to manage datasets")
@@ -80,6 +80,9 @@ def run(arguments=None):
             create_snapshot(args, host)
         elif args.remove:
             remove_snapshot(args, host)
+    elif args.command == "dataset":
+        if args.remove:
+            remove_dataset(args, host)
 
 
 def check_data(args, host, parser):

--- a/orchestration/dagster_orchestration/hca_manage/main.py
+++ b/orchestration/dagster_orchestration/hca_manage/main.py
@@ -82,10 +82,16 @@ def run(arguments=None):
         if args.create:
             create_snapshot(args, host)
         elif args.remove:
-            remove_snapshot(args, host)
+            if query_yes_no("Are you sure?"):
+                remove_snapshot(args, host)
+            else:
+                print("No deletes attempted.")
     elif args.command == "dataset":
         if args.remove:
-            remove_dataset(args, host)
+            if query_yes_no("Are you sure?"):
+                remove_dataset(args, host)
+            else:
+                print("No deletes attempted.")
 
 
 def check_data(args, host, parser):
@@ -128,3 +134,36 @@ def remove_snapshot(args, host):
 def remove_dataset(args, host):
     hca = HcaManage(environment=args.env, data_repo_client=get_api_client(host=host))
     return hca.delete_dataset(dataset_name=args.dataset_name, dataset_id=args.dataset_id)
+
+
+def query_yes_no(question, default="no"):
+    """Ask a yes/no question via raw_input() and return their answer.
+
+    "question" is a string that is presented to the user.
+    "default" is the presumed answer if the user just hits <Enter>.
+        It must be "yes" (the default), "no" or None (meaning
+        an answer is required of the user).
+
+    The "answer" return value is True for "yes" or False for "no".
+    """
+    valid = {"yes": True, "y": True, "ye": True,
+             "no": False, "n": False}
+    if default is None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " [Y/n] "
+    elif default == "no":
+        prompt = " [y/N] "
+    else:
+        raise ValueError(f"invalid default answer: '{default}'")
+
+    while True:
+        sys.stdout.write(question + prompt)
+        choice = input().lower()
+        if default is not None and choice == '':
+            return valid[default]
+        elif choice in valid:
+            return valid[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' "
+                             "(or 'y' or 'n').\n")

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -15,8 +15,8 @@ ProblemCount = namedtuple("ProblemCount", ["duplicates", "null_file_refs"])
 class HcaManage:
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-    def __init__(self, environment: str, dataset: str, data_repo_client: RepositoryApi, project: Optional[str] = None,
-                 data_repo_profile_id: Optional[str] = None):
+    def __init__(self, environment: str, data_repo_client: RepositoryApi, project: Optional[str] = None,
+                 dataset: Optional[str] = None, data_repo_profile_id: Optional[str] = None):
         self.environment = environment
 
         self.project = project

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -245,7 +245,17 @@ class HcaManage:
         return response.id
 
     def delete_dataset(self, dataset_name: Optional[str] = None, dataset_id: Optional[str] = None):
-        pass
+        if dataset_name and not dataset_id:
+            response = self.data_repo_client.enumerate_snapshots(filter=dataset_name)
+            dataset_id = response.items[0].id
+        elif dataset_id and not dataset_name:
+            pass  # let dataset_id argument pass through
+        else:
+            # can't have both/neither provided
+            raise ValueError("You must provide either dataset_name or dataset_id, and cannot provide neither/both.")
+        response = self.data_repo_client.delete_dataset(dataset_id)
+        logging.info(f"Dataset deletion job id: {response.id}")
+        return response.id
 
     # dataset-level checking and soft deleting
     def process_duplicates(self, soft_delete: bool = False):

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -234,7 +234,10 @@ class HcaManage:
     def delete_snapshot(self, snapshot_name: Optional[str] = None, snapshot_id: Optional[str] = None):
         if snapshot_name and not snapshot_id:
             response = self.data_repo_client.enumerate_snapshots(filter=snapshot_name)
-            snapshot_id = response.items[0].id
+            try:
+                snapshot_id = response.items[0].id
+            except IndexError:
+                raise ValueError("The provided snapshot name returned no results.")
         elif snapshot_id and not snapshot_name:
             pass  # let snapshot_id argument pass through
         else:
@@ -247,7 +250,10 @@ class HcaManage:
     def delete_dataset(self, dataset_name: Optional[str] = None, dataset_id: Optional[str] = None):
         if dataset_name and not dataset_id:
             response = self.data_repo_client.enumerate_datasets(filter=dataset_name)
-            dataset_id = response.items[0].id
+            try:
+                dataset_id = response.items[0].id
+            except IndexError:
+                raise ValueError("The provided snapshot name returned no results.")
         elif dataset_id and not dataset_name:
             pass  # let dataset_id argument pass through
         else:

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -232,7 +232,17 @@ class HcaManage:
         return response.id
 
     def delete_snapshot(self, snapshot_name: Optional[str] = None, snapshot_id: Optional[str] = None):
-        pass
+        if snapshot_name and not snapshot_id:
+            response = self.data_repo_client.enumerate_snapshots(filter=snapshot_name)
+            snapshot_id = response.items[0].id
+        elif snapshot_id and not snapshot_name:
+            pass  # let snapshot_id argument pass through
+        else:
+            # can't have both/neither provided
+            raise ValueError("You must provide either snapshot_name or snapshot_id, and cannot provide neither/both.")
+        response = self.data_repo_client.delete_snapshot(snapshot_id)
+        logging.info(f"Snapshot deletion job id: {response.id}")
+        return response.id
 
     def delete_dataset(self, dataset_name: Optional[str] = None, dataset_id: Optional[str] = None):
         pass

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -246,7 +246,7 @@ class HcaManage:
 
     def delete_dataset(self, dataset_name: Optional[str] = None, dataset_id: Optional[str] = None):
         if dataset_name and not dataset_id:
-            response = self.data_repo_client.enumerate_snapshots(filter=dataset_name)
+            response = self.data_repo_client.enumerate_datasets(filter=dataset_name)
             dataset_id = response.items[0].id
         elif dataset_id and not dataset_name:
             pass  # let dataset_id argument pass through

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -134,7 +134,7 @@ class HcaManage:
         :param query: The SQL query to run.
         :return: A set of whatever the query is asking for (assumes that we're only asking for a single column).
         """
-        query_job = self.bigquery_client.query(query)
+        query_job = self.bigquery_client().query(query)
         return {row[0] for row in query_job}
 
     def _format_filename(self, table: str):
@@ -230,6 +230,12 @@ class HcaManage:
 
         logging.info(f"Snapshot creation job id: {response.id}")
         return response.id
+
+    def delete_snapshot(self, snapshot_name: Optional[str] = None, snapshot_id: Optional[str] = None):
+        pass
+
+    def delete_dataset(self, dataset_name: Optional[str] = None, dataset_id: Optional[str] = None):
+        pass
 
     # dataset-level checking and soft deleting
     def process_duplicates(self, soft_delete: bool = False):


### PR DESCRIPTION
## Why
We need to delete a bunch of snapshots and datasets. It is better/faster/easier to do so programmatically rather than repeatedly doing stuff in the OpenAPI docs "try it out" page for Jade.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1583)

## This PR
Adds snapshot and dataset deletion methods to `HcaManage`, updates `HcaManage` to have even more of the initialization arguments be optional, updates the CLI to interact with these new methods, and upgrades the structure of the existing CLI methods a touch.

Note that for the relevant ticket to be complete, this functionality needs to be run on all the snapshots/datasets specified in the ticket.