### PR TITLE
Fix ordering of params

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids.py
@@ -90,8 +90,8 @@ def post_import_validate(context) -> DagsterProblemCount:
     Checks if the target dataset has any rows with duplicate IDs or null file references.
     """
     validator = HcaManage(
-        context.resources.data_repo_client,
         context.solid_config["gcp_env"],
+        context.resources.data_repo_client,
         context.solid_config["google_project_name"],
         context.solid_config["dataset_name"])
     return validator.check_for_all()

--- a/orchestration/dagster_orchestration/hca_orchestration/solids.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids.py
@@ -90,8 +90,8 @@ def post_import_validate(context) -> DagsterProblemCount:
     Checks if the target dataset has any rows with duplicate IDs or null file references.
     """
     validator = HcaManage(
+        context.resources.data_repo_client,
         context.solid_config["gcp_env"],
         context.solid_config["google_project_name"],
-        context.solid_config["dataset_name"],
-        context.resources.data_repo_client)
+        context.solid_config["dataset_name"])
     return validator.check_for_all()


### PR DESCRIPTION
## Why

The Jade client needs to be the second param to HcaManage.

## This PR
* Changes the param ordering
* TODO: This should get caught in a unit test; there is a large refactoring PR in flight that should land before we engage in the needed refactoring to make HcaManage testable against this case (specifically we should be able to assert that BQ was called with the correct project name and dataset which isn't possible atm without significant mocking)