### PR TITLE
Preconfigure Slack resource with its token

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/resources/data_repo.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/data_repo.py
@@ -24,7 +24,7 @@ def base_jade_data_repo_client(init_context: InitResourceContext):
 
 
 @configured(base_jade_data_repo_client)
-def jade_data_repo_client(config):
+def jade_data_repo_client(_config):
     return {
         'api_url': os.environ.get('DATA_REPO_URL'),
     }

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
@@ -1,6 +1,6 @@
 import os
 
-from dagster import configured, resource, String
+from dagster import configured, resource
 from dagster.core.execution.context.init import InitResourceContext
 from dagster_slack import slack_resource
 
@@ -18,9 +18,9 @@ def console_slack_client(init_context: InitResourceContext):
     return ConsoleSlackClient(init_context)
 
 
-@configured(slack_resource, {"token": String})
-def live_slack_client(config):
+@configured(slack_resource)
+def live_slack_client(_config):
     return {
         "channel": os.environ.get("SLACK_NOTIFICATIONS_CHANNEL"),
-        **config,
+        "token": os.environ.get("SLACK_TOKEN"),
     }

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
@@ -21,6 +21,5 @@ def console_slack_client(init_context: InitResourceContext):
 @configured(slack_resource)
 def live_slack_client(_config):
     return {
-        "channel": os.environ.get("SLACK_NOTIFICATIONS_CHANNEL"),
         "token": os.environ.get("SLACK_TOKEN"),
     }

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_resources.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_resources.py
@@ -1,0 +1,14 @@
+import unittest
+
+from dagster.core.execution.context.init import InitResourceContext
+import slack.web.client
+
+from hca_orchestration.resources import live_slack_client
+
+
+class LiveSlackResourceTestCase(unittest.TestCase):
+    # basic test to make sure we're passing valid default configuration into the resource
+    def test_resource_can_be_initialized(self):
+        resource_context = InitResourceContext(resource_config={}, resource_def=live_slack_client)
+        client_instance = live_slack_client.resource_fn(resource_context)
+        self.assertIsInstance(client_instance, slack.web.client.WebClient)


### PR DESCRIPTION
This will let us run Slack-dependent pipelines from the playground, since we won't have easy access to their token. It also removes the step that tries to configure the resource with a channel, which isn't an option it supports.