### PR TITLE
Clean up some bugs/typos in Dagster code

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -1,8 +1,6 @@
 name: Master Validation and Release
 on:
-  push:
-    branches:
-      - master
+  - push
 jobs:
   master-ci:
     runs-on: ubuntu-latest
@@ -11,25 +9,25 @@ jobs:
       - name: Fetch tag history
         run: git fetch --tags
       - uses: google-github-actions/setup-gcloud@v0.2.1
-        name: Setup gcloud for Dataflow tests
-        with:
-          project_id: ${{ secrets.DEV_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_TEST_KEY }}
-          export_default_credentials: true
-      - uses: olafurpg/setup-scala@v10
-        with:
-          java-version: graalvm@20.0.0
-      - name: Check Scala formatting
-        run: sbt scalafmtCheckAll
-      - name: Scala Compile
-        run: sbt Compile/compile Test/compile IntegrationTest/compile
-      - name: Scala Test
-        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      - name: DataflowCheck
-        run: sbt "hca-transformation-pipeline/run --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/inputs/Success --outputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/outputs-to-overwrite --runner=DataflowRunner --project=broad-dsp-monster-hca-dev --region=us-central1 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow"
-      - name: Publish Scala coverage
-        uses: codecov/codecov-action@v1
-      - uses: google-github-actions/setup-gcloud@v0.2.1
+      #   name: Setup gcloud for Dataflow tests
+      #   with:
+      #     project_id: ${{ secrets.DEV_PROJECT_ID }}
+      #     service_account_key: ${{ secrets.GCP_TEST_KEY }}
+      #     export_default_credentials: true
+      # - uses: olafurpg/setup-scala@v10
+      #   with:
+      #     java-version: graalvm@20.0.0
+      # - name: Check Scala formatting
+      #   run: sbt scalafmtCheckAll
+      # - name: Scala Compile
+      #   run: sbt Compile/compile Test/compile IntegrationTest/compile
+      # - name: Scala Test
+      #   run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+      # - name: DataflowCheck
+      #   run: sbt "hca-transformation-pipeline/run --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/inputs/Success --outputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/outputs-to-overwrite --runner=DataflowRunner --project=broad-dsp-monster-hca-dev --region=us-central1 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow"
+      # - name: Publish Scala coverage
+      #   uses: codecov/codecov-action@v1
+      # - uses: google-github-actions/setup-gcloud@v0.2.1
         name: Setup gcloud for pushing Docker images
         with:
           service_account_email: jenkins-gcr-pusher@broad-dsp-monster-dev.iam.gserviceaccount.com
@@ -37,8 +35,8 @@ jobs:
           export_default_credentials: true
       - name: Setup GCR auth
         run: gcloud auth configure-docker --quiet us.gcr.io
-      - name: Push Scala Dataflow Docker image
-        run: sbt publish
+      # - name: Push Scala Dataflow Docker image
+      #   run: sbt publish
       - name: Get artifact slug
         id: get-artifact-slug
         run: 'echo ::set-output name=slug::$(git rev-parse --short "$GITHUB_SHA")'

--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -1,6 +1,8 @@
 name: Master Validation and Release
 on:
-  - push
+  push:
+    branches:
+      - master
 jobs:
   master-ci:
     runs-on: ubuntu-latest
@@ -9,25 +11,25 @@ jobs:
       - name: Fetch tag history
         run: git fetch --tags
       - uses: google-github-actions/setup-gcloud@v0.2.1
-      #   name: Setup gcloud for Dataflow tests
-      #   with:
-      #     project_id: ${{ secrets.DEV_PROJECT_ID }}
-      #     service_account_key: ${{ secrets.GCP_TEST_KEY }}
-      #     export_default_credentials: true
-      # - uses: olafurpg/setup-scala@v10
-      #   with:
-      #     java-version: graalvm@20.0.0
-      # - name: Check Scala formatting
-      #   run: sbt scalafmtCheckAll
-      # - name: Scala Compile
-      #   run: sbt Compile/compile Test/compile IntegrationTest/compile
-      # - name: Scala Test
-      #   run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      # - name: DataflowCheck
-      #   run: sbt "hca-transformation-pipeline/run --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/inputs/Success --outputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/outputs-to-overwrite --runner=DataflowRunner --project=broad-dsp-monster-hca-dev --region=us-central1 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow"
-      # - name: Publish Scala coverage
-      #   uses: codecov/codecov-action@v1
-      # - uses: google-github-actions/setup-gcloud@v0.2.1
+        name: Setup gcloud for Dataflow tests
+        with:
+          project_id: ${{ secrets.DEV_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_TEST_KEY }}
+          export_default_credentials: true
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: graalvm@20.0.0
+      - name: Check Scala formatting
+        run: sbt scalafmtCheckAll
+      - name: Scala Compile
+        run: sbt Compile/compile Test/compile IntegrationTest/compile
+      - name: Scala Test
+        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+      - name: DataflowCheck
+        run: sbt "hca-transformation-pipeline/run --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/inputs/Success --outputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/outputs-to-overwrite --runner=DataflowRunner --project=broad-dsp-monster-hca-dev --region=us-central1 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow"
+      - name: Publish Scala coverage
+        uses: codecov/codecov-action@v1
+      - uses: google-github-actions/setup-gcloud@v0.2.1
         name: Setup gcloud for pushing Docker images
         with:
           service_account_email: jenkins-gcr-pusher@broad-dsp-monster-dev.iam.gserviceaccount.com
@@ -35,8 +37,8 @@ jobs:
           export_default_credentials: true
       - name: Setup GCR auth
         run: gcloud auth configure-docker --quiet us.gcr.io
-      # - name: Push Scala Dataflow Docker image
-      #   run: sbt publish
+      - name: Push Scala Dataflow Docker image
+        run: sbt publish
       - name: Get artifact slug
         id: get-artifact-slug
         run: 'echo ::set-output name=slug::$(git rev-parse --short "$GITHUB_SHA")'

--- a/ops/helmfiles/dagster/environment/dev.yaml
+++ b/ops/helmfiles/dagster/environment/dev.yaml
@@ -4,6 +4,7 @@ env: &envConfig
   HCA_ARGO_URL: https://hca-argo.monster-dev.broadinstitute.org/
   DATA_REPO_URL: https://jade.datarepo-dev.broadinstitute.org/
   HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-dev
+  DATA_REPO_GOOGLE_PROJECT: broad-jade-dev-data
   HCA_GCP_ENV: dev
   SLACK_NOTIFICATIONS_CHANNEL: "#monster-ci"
 

--- a/ops/helmfiles/dagster/environment/prod.yaml
+++ b/ops/helmfiles/dagster/environment/prod.yaml
@@ -4,6 +4,7 @@ env: &envConfig
   HCA_ARGO_URL: https://hca-argo.monster-prod.broadinstitute.org/
   DATA_REPO_URL: https://jade-terra.datarepo-prod.broadinstitute.org/
   HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-prod
+  DATA_REPO_GOOGLE_PROJECT: broad-jade-prod-data
   HCA_GCP_ENV: prod
   SLACK_NOTIFICATIONS_CHANNEL: "#monster-ci"
 

--- a/ops/helmfiles/dagster/environment/prod.yaml
+++ b/ops/helmfiles/dagster/environment/prod.yaml
@@ -4,7 +4,7 @@ env: &envConfig
   HCA_ARGO_URL: https://hca-argo.monster-prod.broadinstitute.org/
   DATA_REPO_URL: https://jade-terra.datarepo-prod.broadinstitute.org/
   HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-prod
-  DATA_REPO_GOOGLE_PROJECT: broad-jade-prod-data
+  DATA_REPO_GOOGLE_PROJECT: broad-datarepo-terra-prod-hca2
   HCA_GCP_ENV: prod
   SLACK_NOTIFICATIONS_CHANNEL: "#monster-ci"
 

--- a/ops/helmfiles/dagster/helmfile.yaml
+++ b/ops/helmfiles/dagster/helmfile.yaml
@@ -47,6 +47,8 @@ releases:
                 # point it at the env config map the daemon generates as a workaround. this will be the
                 # same set of custom env vars as every other component of the system.
                 - name: monster-dagster-daemon-env
+              envSecrets:
+                - name: monster-dagster-secrets
       - dagit:
           envSecrets:
             - name: monster-dagster-secrets
@@ -69,3 +71,6 @@ releases:
                 - name: monster-dagster-daemon-env
               envSecrets:
                 - name: monster-dagster-secrets
+      - dagsterDaemon:
+          envSecrets:
+            - name: monster-dagster-secrets

--- a/orchestration/dagster_orchestration/.env.test
+++ b/orchestration/dagster_orchestration/.env.test
@@ -1,5 +1,6 @@
 HCA_ARGO_URL=https://argo.zombo.com.fake/
 DATA_REPO_URL=https://datarepo.zombo.com.fake/
 HCA_GOOGLE_PROJECT=fake-google-project
+DATA_REPO_GOOGLE_PROJECT=fake-datarepo-project
 HCA_GCP_ENV=dev
 SLACK_NOTIFICATIONS_CHANNEL="#beepbloopfakechannel"

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -166,7 +166,7 @@ class HcaManage:
         :param query: The SQL query to run.
         :return: A set of whatever the query is asking for (assumes that we're only asking for a single column).
         """
-        query_job = self.bigquery_client().query(query)
+        query_job = self.bigquery_client.query(query)
         return {row[0] for row in query_job}
 
     def _format_filename(self, table: str):

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/validate_egress.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/validate_egress.py
@@ -49,7 +49,7 @@ def base_post_import_validate(context: AbstractComputeExecutionContext) -> Dagst
 def post_import_validate(config):
     return {
         'gcp_env': os.environ.get("HCA_GCP_ENV"),
-        'google_project_name': os.environ.get("HCA_GOOGLE_PROJECT"),
+        'google_project_name': os.environ.get("DATA_REPO_GOOGLE_PROJECT"),
         **config,
     }
 


### PR DESCRIPTION
* Fixes misplaced parentheses in HCA manage
* Distinguishes between HCA google project and data repo google project (@raaidbroad could use your guidance to make sure this approach is the correct one)
* Pulls in secrets config in a few Dagster components that we originally missed