### PR TITLE
Set up stage-data pipeline to mirror Argo functionality

### DIFF
--- a/ops/helmfiles/dagster/apply.sh
+++ b/ops/helmfiles/dagster/apply.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# quick shorthand for deploying changes to the helm chart.
+# usage: ./apply.sh [env [target_branch_or_sha]]
+# e.g. ./apply.sh               # deploys the current branch's head to dev
+#      ./apply.sh prod          # deploys the current branch's head to prod
+#      ./apply.sh dev master    # deploys the current head commit on master to dev
+#      ./apply.sh prod a81cc3f  # deploys the commit with the sha a81cc3f to prod
+# note that the specified commit will only affect the version of our python code that gets deployed to the cluster.
+# this command will always use the version of the helm chart you have saved locally.
+export TARGET_HEAD=${2:-HEAD}
+ENV=${1:-dev} GIT_SHORTHASH=$(git rev-parse --short $TARGET_HEAD) helmfile apply

--- a/ops/helmfiles/dagster/environment/dev.yaml
+++ b/ops/helmfiles/dagster/environment/dev.yaml
@@ -5,8 +5,9 @@ env: &envConfig
   DATA_REPO_URL: https://jade.datarepo-dev.broadinstitute.org/
   HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-dev
   DATA_REPO_GOOGLE_PROJECT: broad-jade-dev-data
+  HCA_TEMP_STORAGE_BUCKET: broad-dsp-monster-hca-dev-temp-storage
+  HCA_DATAFLOW_SERVICE_ACCOUNT: hca-dataflow-runner@broad-dsp-monster-hca-dev.iam.gserviceaccount.com
   HCA_GCP_ENV: dev
-  SLACK_NOTIFICATIONS_CHANNEL: "#monster-ci"
 
 dagit:
   env: *envConfig

--- a/ops/helmfiles/dagster/environment/global.yaml
+++ b/ops/helmfiles/dagster/environment/global.yaml
@@ -1,0 +1,15 @@
+env: &envConfig
+  SLACK_NOTIFICATIONS_CHANNEL: "#monster-ci"
+  DATAFLOW_STARTING_WORKERS: 4
+  DATAFLOW_MAX_WORKERS: 16
+  GCLOUD_REGION: us-central1
+  DATAFLOW_WORKER_MACHINE_TYPE: n1-standard-4
+  KUBERNETES_NAMESPACE: dagster
+  HCA_KUBERNETES_SERVICE_ACCOUNT: monster-dagster
+  TRANSFORM_PIPELINE_IMAGE: us.gcr.io/broad-dsp-gcr-public/hca-transformation-pipeline
+  TRANSFORM_PIPELINE_IMAGE_VERSION: latest
+
+dagit:
+  env: *envConfig
+dagsterDaemon:
+  env: *envConfig

--- a/ops/helmfiles/dagster/environment/prod.yaml
+++ b/ops/helmfiles/dagster/environment/prod.yaml
@@ -5,8 +5,9 @@ env: &envConfig
   DATA_REPO_URL: https://jade-terra.datarepo-prod.broadinstitute.org/
   HCA_GOOGLE_PROJECT: broad-dsp-monster-hca-prod
   DATA_REPO_GOOGLE_PROJECT: broad-datarepo-terra-prod-hca2
+  HCA_TEMP_STORAGE_BUCKET: broad-dsp-monster-hca-prod-temp-storage
+  HCA_DATAFLOW_SERVICE_ACCOUNT: hca-dataflow-runner@broad-dsp-monster-hca-prod.iam.gserviceaccount.com
   HCA_GCP_ENV: prod
-  SLACK_NOTIFICATIONS_CHANNEL: "#monster-ci"
 
 dagit:
   env: *envConfig

--- a/ops/helmfiles/dagster/helmfile.lock
+++ b/ops/helmfiles/dagster/helmfile.lock
@@ -5,9 +5,9 @@ dependencies:
   version: 0.0.6
 - name: dagster
   repository: https://dagster-io.github.io/helm
-  version: 0.10.9
+  version: 0.11.1
 - name: serviceaccount-psp
   repository: https://broadinstitute.github.io/datarepo-helm
   version: 0.0.3
-digest: sha256:e24418835037055459a208a6db1fcd51298a5ad5eed463a684c7be8b346d2533
-generated: "2021-03-16T10:07:03.024316-04:00"
+digest: sha256:71108feac646d69d0e57cd7a714ceabb58bbd046b8944c35d61702e405ccc271
+generated: "2021-03-23T09:47:07.911211-04:00"

--- a/ops/helmfiles/dagster/helmfile.yaml
+++ b/ops/helmfiles/dagster/helmfile.yaml
@@ -33,6 +33,7 @@ releases:
     chart: dagster/dagster   # chart name
     missingFileHandler: Warn
     values:
+      - environment/global.yaml
       - environment/{{ requiredEnv "ENV" }}.yaml
       - rbacEnabled: true
       - postgresql:

--- a/orchestration/dagster_orchestration/.env.test
+++ b/orchestration/dagster_orchestration/.env.test
@@ -4,3 +4,5 @@ HCA_GOOGLE_PROJECT=fake-google-project
 DATA_REPO_GOOGLE_PROJECT=fake-datarepo-project
 HCA_GCP_ENV=dev
 SLACK_NOTIFICATIONS_CHANNEL="#beepbloopfakechannel"
+HCA_TEMP_STORAGE_BUCKET=this-temp-storage-bucket-is-a-lie
+HCA_DATAFLOW_SERVICE_ACCOUNT=hca-dataflow-runner@why-are-you-making-gcloud-calls-in-tests.biz

--- a/orchestration/dagster_orchestration/hca_orchestration/environments/test_stage_data.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/environments/test_stage_data.yaml
@@ -6,4 +6,5 @@ solids:
   pre_process_metadata:
     config:
       input_prefix: example_input_prefix
-      output_prefix: example_output_prefix
+      staging_bucket_name: example_staging_bucket_name
+      staging_prefix_name: example_staging_prefix_name

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/stage_data.py
@@ -1,6 +1,6 @@
 from dagster import ModeDefinition, pipeline
 
-from hca_orchestration.solids.stage_data import clear_staging_dir, pre_process_metadata, submit_file_ingest
+from hca_orchestration.solids.stage_data import clear_staging_dir, pre_process_metadata
 from hca_orchestration.resources import dataflow_beam_runner, local_beam_runner, google_storage_client, \
     jade_data_repo_client, test_beam_runner, local_storage_client, noop_data_repo_client
 
@@ -37,13 +37,4 @@ test_mode = ModeDefinition(
     mode_defs=[prod_mode, local_mode, test_mode]
 )
 def stage_data():
-    middle = pre_process_metadata(start=clear_staging_dir())
-    entities = ["analysis_file", "analysis_process", "analysis_protocol"]
-
-    outs = []
-    for e in entities:
-        submit = submit_file_ingest.alias(e)
-        outs.append(submit(middle))
-
-    final = submit_file_ingest.alias("final")
-    final(outs)
+    pre_process_metadata(start=clear_staging_dir())

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/beam.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/beam.py
@@ -29,9 +29,9 @@ class DataflowCloudConfig:
     def __post_init__(self):
         self.subnetwork = '/'.join([
             'regions',
-            self.cloud_config.region,
+            self.region,
             'subnetworks',
-            self.cloud_config.subnet_name,
+            self.subnet_name,
         ])
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/beam.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/beam.py
@@ -49,7 +49,7 @@ class DataflowBeamRunner:
         self,
         job_name: str,
         input_prefix: str,
-        output_prefix: str
+        output_prefix: str,
     ) -> None:
         args_dict = {
             'runner': 'dataflow',
@@ -137,7 +137,7 @@ class DataflowBeamRunner:
     "temp_bucket": Field(StringSource),
     "image_name": Field(StringSource),
     "image_version": Field(StringSource),
-    "namespace": Field(StringSource)
+    "namespace": Field(StringSource),
 })
 def base_dataflow_beam_runner(init_context: InitResourceContext):
     cloud_config = DataflowCloudConfig(
@@ -182,15 +182,15 @@ def dataflow_beam_runner(config):
 @dataclass
 class LocalBeamRunner:
     working_dir: str
+    logger: DagsterLogManager
     # TODO this is hardcoded to the HCA transformation pipeline for now
     target_class: str = 'hca-transformation-pipeline'
-    logger: DagsterLogManager
 
     def run(
         self,
         job_name: str,
         input_prefix: str,
-        output_prefix: str
+        output_prefix: str,
     ) -> None:
         self.logger.info("Local beam runner")
         subprocess.run(

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/beam.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/beam.py
@@ -183,8 +183,7 @@ def dataflow_beam_runner(config):
 class LocalBeamRunner:
     working_dir: str
     logger: DagsterLogManager
-    # TODO this is hardcoded to the HCA transformation pipeline for now
-    target_class: str = 'hca-transformation-pipeline'
+    target_class: str
 
     def run(
         self,
@@ -201,11 +200,13 @@ class LocalBeamRunner:
 
 
 @resource({
-    "working_dir": Field(StringSource)
+    "working_dir": Field(StringSource),
+    "target_class": Field(StringSource),  # 'hca-transformation-pipeline' is usually what you want
 })
 def local_beam_runner(init_context: InitResourceContext):
     return LocalBeamRunner(
         working_dir=init_context.resource_config["working_dir"],
+        target_class=init_context.resource_config["target_class"],
         logger=init_context.log_manager,
     )
 

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/data_repo.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/data_repo.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-import os
 
 from dagster import configured, resource, StringSource, Field
 from dagster.core.execution.context.init import InitResourceContext
@@ -26,7 +25,7 @@ def base_jade_data_repo_client(init_context: InitResourceContext):
 @configured(base_jade_data_repo_client)
 def jade_data_repo_client(_config):
     return {
-        'api_url': os.environ.get('DATA_REPO_URL'),
+        'api_url': {'env': 'DATA_REPO_URL'},
     }
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
@@ -1,5 +1,3 @@
-import os
-
 from dagster import configured, resource
 from dagster.core.execution.context.init import InitResourceContext
 from dagster_slack import slack_resource
@@ -21,5 +19,5 @@ def console_slack_client(init_context: InitResourceContext):
 @configured(slack_resource)
 def live_slack_client(_config):
     return {
-        "token": os.environ.get("SLACK_TOKEN"),
+        'token': {'env': "SLACK_TOKEN"},
     }

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
@@ -19,5 +19,5 @@ def console_slack_client(init_context: InitResourceContext):
 @configured(slack_resource)
 def live_slack_client(_config):
     return {
-        'token': {'env': "SLACK_TOKEN"},
+        'token': {'env': 'SLACK_TOKEN'},
     }

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
@@ -28,7 +28,7 @@ def clear_staging_dir(context: AbstractComputeExecutionContext) -> int:
     for blob in blobs:
         blob.delete()
         deletions_count += 1
-    context.log.debug(f"--clear_staging_dir found {deletions_count} blobs to delete under {staging_prefix_name}")
+    context.log.debug(f"--clear_staging_dir deleted {deletions_count} blobs under {staging_prefix_name}")
     return deletions_count
 
 
@@ -57,16 +57,3 @@ def pre_process_metadata(context: AbstractComputeExecutionContext) -> Nothing:
         input_prefix=context.solid_config["input_prefix"],
         output_prefix=f'gs://{bucket_name}/{prefix_name}'
     )
-
-
-@solid(
-    required_resource_keys={"data_repo_client"},
-    input_defs=[InputDefinition("start", Nothing)]
-)
-def submit_file_ingest(context: AbstractComputeExecutionContext) -> Nothing:
-    """
-    This will submit a dataset for ingestion to the data repo
-    TODO This is a noop for now
-    """
-    datasets = context.resources.data_repo_client.enumerate_datasets()
-    context.log.debug(f"Enumerate found {datasets.total} datasets in the repo")

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
@@ -50,7 +50,7 @@ def pre_process_metadata(context: AbstractComputeExecutionContext) -> Nothing:
     bucket_name = context.solid_config['staging_bucket_name']
     prefix_name = context.solid_config['staging_prefix_name']
 
-    kebabified_output_prefix = re.sub(r"[^A-Za-z0-9]", "-",  prefix_name)
+    kebabified_output_prefix = re.sub(r"[^A-Za-z0-9]", "-", prefix_name)
 
     context.resources.beam_runner.run(
         job_name=f"hca-stage-metadata-{kebabified_output_prefix}",

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
@@ -4,7 +4,7 @@ from dagster import solid, InputDefinition, Nothing, String
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 
 
-STAGING_BUCKET_CONFIG = {
+STAGING_BUCKET_CONFIG_SCHEMA = {
     "staging_bucket_name": String,
     "staging_prefix_name": String,
 }
@@ -12,7 +12,7 @@ STAGING_BUCKET_CONFIG = {
 
 @solid(
     required_resource_keys={"storage_client"},
-    config_schema=STAGING_BUCKET_CONFIG,
+    config_schema=STAGING_BUCKET_CONFIG_SCHEMA,
 )
 def clear_staging_dir(context: AbstractComputeExecutionContext) -> int:
     """
@@ -35,7 +35,7 @@ def clear_staging_dir(context: AbstractComputeExecutionContext) -> int:
 @solid(
     required_resource_keys={"beam_runner"},
     config_schema={
-        **STAGING_BUCKET_CONFIG,
+        **STAGING_BUCKET_CONFIG_SCHEMA,
         "input_prefix": String,
     },
     input_defs=[InputDefinition("start", Nothing)],

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/stage_data.py
@@ -46,12 +46,16 @@ def pre_process_metadata(context: AbstractComputeExecutionContext) -> Nothing:
     """
     context.log.info("--pre_process_metadata")
 
-    kebabified_output_prefix = re.sub(r"[^A-Za-z0-9]", "-",  context.solid_config['staging_prefix_name'])
+    # not strictly required, but makes the ensuing lines a lot shorter
+    bucket_name = context.solid_config['staging_bucket_name']
+    prefix_name = context.solid_config['staging_prefix_name']
+
+    kebabified_output_prefix = re.sub(r"[^A-Za-z0-9]", "-",  prefix_name)
 
     context.resources.beam_runner.run(
-        f"hca-stage-metadata-{kebabified_output_prefix}",
-        context.solid_config["input_prefix"],
-        f'gs://{context.solid_config["staging_bucket_name"]}/{context.solid_config["staging_prefix_name"]}'
+        job_name=f"hca-stage-metadata-{kebabified_output_prefix}",
+        input_prefix=context.solid_config["input_prefix"],
+        output_prefix=f'gs://{bucket_name}/{prefix_name}'
     )
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/validate_egress.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/validate_egress.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any
 
-from dagster import configured, solid, InputDefinition, String, DagsterType
+from dagster import configured, DagsterType, InputDefinition, solid, String, StringSource
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 
 from hca_manage.manage import HcaManage, ProblemCount
@@ -20,7 +20,7 @@ DagsterProblemCount: DagsterType = DagsterType(
 
 
 POST_VALIDATION_SETTINGS_SCHEMA = {
-    "gcp_env": String,
+    "gcp_env": StringSource,
     "dataset_name": String,
 }
 
@@ -29,7 +29,7 @@ POST_VALIDATION_SETTINGS_SCHEMA = {
     required_resource_keys={"data_repo_client"},
     config_schema={
         **POST_VALIDATION_SETTINGS_SCHEMA,
-        "google_project_name": String,
+        "google_project_name": StringSource,
     }
 )
 def base_post_import_validate(context: AbstractComputeExecutionContext) -> DagsterProblemCount:
@@ -48,8 +48,8 @@ def base_post_import_validate(context: AbstractComputeExecutionContext) -> Dagst
 @configured(base_post_import_validate, {"dataset_name": String})
 def post_import_validate(config):
     return {
-        'gcp_env': os.environ.get("HCA_GCP_ENV"),
-        'google_project_name': os.environ.get("DATA_REPO_GOOGLE_PROJECT"),
+        'gcp_env': {'env': 'HCA_GCP_ENV'},
+        'google_project_name': {'env': 'DATA_REPO_GOOGLE_PROJECT'},
         **config,
     }
 

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/validate_egress.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/validate_egress.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 
 from dagster import configured, DagsterType, InputDefinition, solid, String, StringSource
@@ -59,7 +58,7 @@ def post_import_validate(config):
     input_defs=[InputDefinition("validation_results", DagsterProblemCount)],
     config_schema={
         **POST_VALIDATION_SETTINGS_SCHEMA,
-        "channel": String,
+        "channel": StringSource,
     }
 )
 def base_notify_slack_of_egress_validation_results(
@@ -90,7 +89,7 @@ def base_notify_slack_of_egress_validation_results(
 @configured(base_notify_slack_of_egress_validation_results, {"dataset_name": String})
 def notify_slack_of_egress_validation_results(config):
     return {
-        'gcp_env': os.environ.get("HCA_GCP_ENV"),
-        'channel': os.environ.get("SLACK_NOTIFICATIONS_CHANNEL"),
+        'gcp_env': {'env': 'HCA_GCP_ENV'},
+        'channel': {'env': 'SLACK_NOTIFICATIONS_CHANNEL'},
         **config,
     }

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_resources.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_resources.py
@@ -1,14 +1,55 @@
+import os
 import unittest
+from unittest import mock
 
-from dagster.core.execution.context.init import InitResourceContext
+from dagster import execute_solid, ModeDefinition, solid
 import slack.web.client
 
-from hca_orchestration.resources import live_slack_client
+from hca_orchestration.resources.beam import DataflowBeamRunner
+from hca_orchestration.resources import dataflow_beam_runner, live_slack_client
+
+
+# n.b. 2021-03-18
+# dagster support for testing resources in isolation is currently very weak
+# and in active development, expect this section to use more robust tooling
+# as it becomes available over the next few months
+def initialize_resource(resource_def, config={}):
+    # to initialize a resource, we need to initialize a context for it by setting up a mock solid
+    # that requires it. details of the solid aren't important. this will get a lot more lightweight
+    # as new tooling is released.
+    mode = ModeDefinition(name='fake', resource_defs={'chungus': resource_def})
+
+    @solid(required_resource_keys={'chungus'})
+    def noop(context):
+        return context.resources.chungus
+
+    return execute_solid(noop, mode).output_value()
 
 
 class LiveSlackResourceTestCase(unittest.TestCase):
     # basic test to make sure we're passing valid default configuration into the resource
+    @mock.patch.dict(os.environ, {
+        **os.environ,
+        'SLACK_TOKEN': 'jeepers',
+    })
     def test_resource_can_be_initialized(self):
-        resource_context = InitResourceContext(resource_config={}, resource_def=live_slack_client)
-        client_instance = live_slack_client.resource_fn(resource_context)
+        client_instance = initialize_resource(live_slack_client)
         self.assertIsInstance(client_instance, slack.web.client.WebClient)
+
+
+class DataflowBeamRunnerTestCase(unittest.TestCase):
+    @mock.patch.dict(os.environ, {
+        **os.environ,
+        'DATAFLOW_SUBNET_NAME': 'snubnet',
+        'GCLOUD_REGION': 'ec-void1',
+        'DATAFLOW_WORKER_MACHINE_TYPE': 'most-expensive-4',
+        'DATAFLOW_STARTING_WORKERS': '2',   # these are marked as ints behind the scenes, but
+        'DATAFLOW_MAX_WORKERS': '9999999',  # dagster handles translating them
+        'HCA_KUBERNETES_SERVICE_ACCOUNT': 'all-seeing-eye@iam.zombo.com',
+        'TRANSFORM_PIPELINE_IMAGE': 'dorian-gray',
+        'TRANSFORM_PIPELINE_IMAGE_VERSION': '1890',
+        'KUBERNETES_NAMESPACE': 'gamespace',
+    })
+    def test_resource_can_be_initialized(self):
+        client_instance = initialize_resource(dataflow_beam_runner)
+        self.assertIsInstance(client_instance, DataflowBeamRunner)

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -6,26 +6,26 @@ authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-dagster = "^0.10.5"
+argo-workflows = "^5.0.0"
+cached-property = "^1.5.2"
+dagster = "^0.11.0"
+dagster-k8s = "^0.11.0"
+dagster-postgres = "^0.11.0"
+dagster-slack = "^0.11.0"
+data-repo-client = "^1.0.194.post5"
 google-cloud-bigquery = "^2.4.0"
 google-cloud-storage = "^1.3.5"
-dagster-k8s = "^0.10.5"
-data-repo-client = "^1.0.194.post5"
-argo-workflows = "^5.0.0"
-dagster-postgres = "^0.10.9"
 python-dateutil = "^2.8.1"
 typing-extensions = "^3.7.4"
-dagster-slack = "^0.10.9"
-cached-property = "^1.5.2"
 
 [tool.poetry.dev-dependencies]
-pdbpp = "^0.10.2"
-pytest = "^6.2.1"
-dagit = "^0.10.5"
-flake8 = "^3.8.4"
 autopep8 = "^1.5.5"
-pre-commit = "^2.11.0"
+dagit = "^0.11.0"
+flake8 = "^3.8.4"
 mypy = "^0.812"
+pdbpp = "^0.10.2"
+pre-commit = "^2.11.0"
+pytest = "^6.2.1"
 pytest-dotenv = "^0.5.2"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
* Moves default config for the dataflow beam runner into environment variables
* Updates our preconfiguration code to draw from env vars in the correct way
* Pulls over proper job name generation from Argo
* Parameterizes several hardcoded options passed to dataflow
* Removes no-op ingest submission from the pipeline

## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1609)