### PR TITLE
Run test transformation pipeline against updated dataset

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -16,6 +16,26 @@ jobs:
           project_id: ${{ secrets.DEV_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_TEST_KEY }}
           export_default_credentials: true
+      - name: Set up Python 3.9 for dataflow tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.1.1
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-poetry
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('${{ github.workspace }}/orchestration/dagster_orchestration/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: poetry install --no-dev
+        working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
@@ -25,8 +45,26 @@ jobs:
         run: sbt Compile/compile Test/compile IntegrationTest/compile
       - name: Scala Test
         run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      - name: DataflowCheck
-        run: sbt "hca-transformation-pipeline/run --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/inputs/Success --outputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/outputs-to-overwrite --runner=DataflowRunner --project=broad-dsp-monster-hca-dev --region=us-central1 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow"
+      - name: Run Dataflow against test data
+        env:
+          GITHUB_SHA: ${{github.sha}}
+        run: >
+          sbt "hca-transformation-pipeline/run
+                 --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/ebi_test
+                 --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
+                 --runner=DataflowRunner
+                 --project=broad-dsp-monster-hca-dev
+                 --region=us-central1
+                 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow
+                 --workerMachineType=n1-standard-4
+                 --numWorkers=16
+                 --experiments=shuffle_mode=service"
+      - name: Verify Dataflow output
+        env:
+          GITHUB_SHA: ${{github.sha}}
+        run: >
+          poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
+        working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration/hca_manage
       - name: Publish Scala coverage
         uses: codecov/codecov-action@v1
       - uses: google-github-actions/setup-gcloud@v0.2.1

--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_SHA: ${{github.sha}}
         run: >
           sbt "hca-transformation-pipeline/run
-                 --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/ebi_test
+                 --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/test_data
                  --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
                  --runner=DataflowRunner
                  --project=broad-dsp-monster-hca-dev
@@ -63,7 +63,7 @@ jobs:
         env:
           GITHUB_SHA: ${{github.sha}}
         run: >
-          poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
+          poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected_output -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
         working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration/hca_manage
       - name: Publish Scala coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -28,7 +28,7 @@ jobs:
           cache-name: cache-poetry
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('${{ github.workspace }}/orchestration/dagster_orchestration/pyproject.toml') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./orchestration/dagster_orchestration/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -22,5 +22,13 @@ jobs:
         run: sbt Compile/compile Test/compile IntegrationTest/compile
       - name: Test
         run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+      - name: DataflowCheck
+          env:
+            GITHUB_SHA: ${{github.sha}}
+          run: >
+            sbt "hca-transformation-pipeline/run
+                --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/ebi_test
+                --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
+                --runner=direct"
       - name: Publish coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -22,13 +22,5 @@ jobs:
         run: sbt Compile/compile Test/compile IntegrationTest/compile
       - name: Test
         run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      - name: DataflowCheck
-          env:
-            GITHUB_SHA: ${{github.sha}}
-          run: >
-            sbt "hca-transformation-pipeline/run
-                --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/ebi_test
-                --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
-                --runner=direct"
       - name: Publish coverage
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ charts/
 logs/errors.log
 __pycache__
 poetry.lock
+.DS_Store

--- a/orchestration/dagster_orchestration/hca_manage/diff_dirs.py
+++ b/orchestration/dagster_orchestration/hca_manage/diff_dirs.py
@@ -1,0 +1,41 @@
+"""
+Compares the contents of two google storage paths via their md5
+"""
+import argparse
+import logging
+
+import google.auth
+from google.cloud import storage
+
+logging.basicConfig(level=logging.INFO)
+
+
+def run(project, source_bucket, source_prefix, target_bucket, target_prefix):
+    creds, _ = google.auth.default()
+    storage_client = storage.Client(project=project, credentials=creds)
+    expected_blobs = {blob.name.replace(source_prefix, ''): blob.md5_hash
+                      for blob in storage_client.list_blobs(source_bucket,
+                                                            prefix=source_prefix)}
+
+    logging.info(f"project = {project}, "
+                 f"source_bucket = {source_bucket}, "
+                 f"source_prefix = {source_prefix}, "
+                 f"target_bucket = {target_bucket}, "
+                 f"target_prefix = {target_prefix}")
+    output_blobs = {blob.name.replace(target_prefix, ''): blob.md5_hash
+                    for blob in storage_client.list_blobs(target_bucket,
+                                                          prefix=target_prefix)}
+
+    assert expected_blobs == output_blobs, "Output results differ from expected"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--project")
+    parser.add_argument("-sb", "--source_bucket")
+    parser.add_argument("-sp", "--source_prefix")
+
+    parser.add_argument("-tb", "--target_bucket")
+    parser.add_argument("-tp", "--target_prefix")
+    args = parser.parse_args()
+    run(args.project, args.source_bucket, args.source_prefix, args.target_bucket, args.target_prefix)


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-952)
We have a test dataset provided by EBI. I have modified it to remove most of the data files and get a representative test case for import. We need to run our dataflow check against this dataset and check it against a set of known good outputs.

## This PR
* Placed the "slimmed" dataset into our test storage bucket at `gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small`
* Placed the output of a dataflow run at `gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/expected_output`. 
* Adds a simple script to diff the output of a test dataflow run and the expected output dir. As we modify the transformation pipeline (i.e., to accommodate schema changes), I expect the flow to be something like:
    * Modify transformation pipeline and ensure unit tests run
    * Test in dataflow and get output
    * 👁️  the output and if good, put it in the `ebi_small/expected_output` directory
* I have not modified the `validate-pull-request.yaml` action to keep the scope of this PR down and to let us test out this testing  mechanism before introducing it more broadly.

## TODO
- [ ] Ticket the follow-on to introduce this test in the `validate-pull-request.yaml` action
