### PR TITLE
Fix autopep8 config to respect our linter settings

### DIFF
--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -37,7 +37,7 @@ jobs:
       run: poetry install
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
     - name: Enforce coding style guide
-      run: poetry run flake8
+      run: poetry run autopep8 --recursive --diff --exit-code .
       working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
       if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails
     - name: Check static types

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -29,6 +29,7 @@ class HcaManage:
     bucket_project: str = field(init=False)
     bucket: str = field(init=False)
     base_url: str = field(init=False)
+    # big big chungus big chungus big chungus big big chungus big chungus big chungus big big chungus big chungus big chungus big big chungus big chungus big chungus
     reader_list: str = field(init=False)
 
     def __post_init__(self):

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -29,7 +29,6 @@ class HcaManage:
     bucket_project: str = field(init=False)
     bucket: str = field(init=False)
     base_url: str = field(init=False)
-    # big big chungus big chungus big chungus big big chungus big chungus big chungus big big chungus big chungus big chungus big big chungus big chungus big chungus
     reader_list: str = field(init=False)
 
     def __post_init__(self):

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -34,3 +34,8 @@ manage = "hca_manage.main:run"
 [build-system]
 requires = ["poetry-core=^1.1.5"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.autopep8]
+aggressive = 1
+exclude = ".pytest_cache,__pycache__"
+max_line_length = 120

--- a/orchestration/dagster_orchestration/tox.ini
+++ b/orchestration/dagster_orchestration/tox.ini
@@ -1,3 +1,0 @@
-[flake8]
-exclude = .pytest_cache,__pycache__
-max_line_length = 120


### PR DESCRIPTION
## Why

Previously we had been directly configuring Flake8 with the `tox.ini` file, but our auto-linter used in our pre-commit hooks prioritizes pyproject.toml (which contained no config) over that file. I've moved the linter config to that file and enabled aggressive mode, to ensure it more aggressively wraps and trims long comments.
## This PR