### PR TITLE
[DSPDC-1684] Add release sanity check script

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/diff_dirs.py
+++ b/orchestration/dagster_orchestration/hca_manage/diff_dirs.py
@@ -7,11 +7,13 @@ import logging
 import google.auth
 from google.cloud import storage
 
+from hca_orchestration.contrib import google as hca_google
+
 logging.basicConfig(level=logging.INFO)
 
 
 def run(project, source_bucket, source_prefix, target_bucket, target_prefix):
-    creds, _ = google.auth.default()
+    creds = hca_google.get_credentials()
     storage_client = storage.Client(project=project, credentials=creds)
     expected_blobs = {blob.name.replace(source_prefix, ''): blob.md5_hash
                       for blob in storage_client.list_blobs(source_bucket,

--- a/orchestration/dagster_orchestration/hca_manage/manage.py
+++ b/orchestration/dagster_orchestration/hca_manage/manage.py
@@ -10,6 +10,7 @@ from cached_property import cached_property
 from data_repo_client import RepositoryApi, DataDeletionRequest, SnapshotRequestModel, SnapshotRequestContentsModel
 import google.auth
 from google.cloud import bigquery, storage
+from hca_orchestration.contrib import google as hca_google
 
 
 @dataclass
@@ -60,14 +61,6 @@ class HcaManage:
     @cached_property
     def bigquery_client(self) -> bigquery.client.Client:
         return bigquery.Client(project=self.project)
-
-    @cached_property
-    def gcp_creds(self):
-        # use application default credentials to seamlessly work across monster devs
-        # assumes `gcloud auth application-default login` has been run
-        creds, _ = google.auth.default()
-
-        return creds
 
     # bigquery interactions
     def get_all_table_names(self) -> Set[str]:
@@ -214,7 +207,7 @@ class HcaManage:
         :param target_table: The table name with which to format the target filename.
         :return: The gs-path of the uploaded file.
         """
-        storage_client = storage.Client(project=self.bucket_project, credentials=self.gcp_creds)
+        storage_client = storage.Client(project=self.bucket_project, credentials=hca_google.get_credentials())
         bucket = storage_client.bucket(self.bucket)
         target_filename = self._format_filename(table=target_table)
         blob = bucket.blob(target_filename)

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -74,7 +74,7 @@ def verify(start_date, manifest_file, gs_project, bq_project, dataset):
     for row in load_history:
         tdr_load_totals[row[0]] = row[1]
         if row[0] not in expected_load_totals:
-            logging.warning(f"{row[0]} not in manifest but was imported")
+            logging.warning(f"⚠️ {row[0]} not in manifest but was imported")
 
     for area in expected_load_totals:
         if area in tdr_load_totals:

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -1,0 +1,100 @@
+"""
+Given a file containing a list of constituent staging dirs for a DCP release (aka a manifest),
+verify that data has been loaded from each of them to the target DCP dataset and the count of loaded files
+matches the # in the staging area
+
+All datarepo load totals are inferred from a supplied start date for the import process.
+
+Example invocation:
+python verify_release_manifest.py -s 2021-03-24 -f testing.csv -g fake-gs-project -b fake-bq-project -d fake-dataset
+"""
+import argparse
+import logging
+
+import google.auth
+from google.cloud import bigquery, storage
+from urllib.parse import urlparse
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
+
+
+def get_expected_load_totals(storage_client, staging_areas):
+    """
+    Given a list of GS staging areas, count the files present in each /data subdir
+    """
+    expected = {}
+    for staging_area in staging_areas:
+        url = urlparse(staging_area)
+        prefix = f"{url.path.lstrip('/')}/data/"
+        blobs = list(storage_client.list_blobs(url.netloc, prefix=prefix))
+        expected[staging_area] = len(blobs)
+    return expected
+
+
+def get_load_history(bq_project, dataset, start_date):
+    client = bigquery.Client(project=bq_project)
+
+    # Determine the number of distinct files loaded after the given start date, grouped by staging area
+    query = f"""
+                WITH base as (
+                    SELECT distinct(source_name)
+                    FROM `datarepo_{dataset}.datarepo_load_history`
+                    WHERE load_time >= '{start_date}'
+                    AND state = 'succeeded'
+                )
+                SELECT REGEXP_EXTRACT(source_name, '(gs://.*)/data/.*$') AS bucket, count(*) as cnt
+                FROM base GROUP by bucket;
+                """
+    query_job = client.query(query)
+
+    # hydrate the rows
+    return list([row for row in query_job])
+
+
+def parse_manifest_file(manifest_file):
+    staging_areas = []
+    with open(manifest_file) as manifest_file:
+        for area in manifest_file:
+            # some of the staging areas submitted via the form need slight cleanup
+            staging_areas.append(area.rstrip('\n').rstrip('/'))
+    return staging_areas
+
+
+def verify(start_date, manifest_file, gs_project, bq_project, dataset):
+    creds, _ = google.auth.default()
+
+    logging.info("Parsing manifest and inspecting staging areas...")
+    storage_client = storage.Client(project=gs_project, credentials=creds)
+    staging_areas = parse_manifest_file(manifest_file)
+    expected_load_totals = get_expected_load_totals(storage_client, staging_areas)
+
+    logging.info("Inspecting load history in bigquery...")
+    tdr_load_totals = {}
+    load_history = get_load_history(bq_project, dataset, start_date)
+    for row in load_history:
+        tdr_load_totals[row[0]] = row[1]
+        if row[0] not in expected_load_totals:
+            logging.warning(f"{row[0]} not in manifest but was imported")
+
+    for area in expected_load_totals:
+        if area in tdr_load_totals:
+            expected_count = expected_load_totals[area]
+            if expected_count != tdr_load_totals[area]:
+                logging.error(f"Mismatched file count: staging_area = {area}, "
+                              f"imported = {tdr_load_totals[area]}, expected = {expected_count}")
+            else:
+                logging.info(f"staging_area = {area}, imported = {tdr_load_totals[area]}, expected = {expected_count}")
+        else:
+            logging.error(f"{area} has not been imported")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--start_date", required=True)
+    parser.add_argument("-f", "--manifest_file", required=True)
+    parser.add_argument("-g", "--gs_project", required=True)
+    parser.add_argument("-b", "--bq_project", required=True)
+    parser.add_argument("-d", "--dataset", required=True)
+    args = parser.parse_args()
+
+    verify(args.start_date, args.manifest_file, args.gs_project, args.bq_project, args.dataset)

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -91,8 +91,12 @@ def verify(start_date, manifest_file, gs_project, bq_project, dataset):
         logging.warning(f"⚠️ {unexpected_area} not in manifest but was imported")
 
     success = True
+    total_loaded_count = 0
+    total_expected_count = 0
     for area, expected_count in expected_load_totals.items():
+        total_expected_count += expected_count
         if area in tdr_load_totals:
+            total_loaded_count += tdr_load_totals[area]
             expected_count = expected_load_totals[area]
             if expected_count != tdr_load_totals[area]:
                 logging.error(f"❌ Mismatched file count: staging_area = {area}, "
@@ -104,6 +108,8 @@ def verify(start_date, manifest_file, gs_project, bq_project, dataset):
         else:
             logging.error(f"❌ {area} has not been imported")
             success = False
+    logging.info('-' * 80)
+    logging.info(f"Total files staged = {total_expected_count}, total files loaded = {total_loaded_count}")
     return success
 
 

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -15,7 +15,7 @@ import google.auth
 from google.cloud import bigquery, storage
 from urllib.parse import urlparse
 
-logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
 def get_expected_load_totals(storage_client, staging_areas):
@@ -80,12 +80,13 @@ def verify(start_date, manifest_file, gs_project, bq_project, dataset):
         if area in tdr_load_totals:
             expected_count = expected_load_totals[area]
             if expected_count != tdr_load_totals[area]:
-                logging.error(f"Mismatched file count: staging_area = {area}, "
+                logging.error(f"❌ Mismatched file count: staging_area = {area}, "
                               f"imported = {tdr_load_totals[area]}, expected = {expected_count}")
             else:
-                logging.info(f"staging_area = {area}, imported = {tdr_load_totals[area]}, expected = {expected_count}")
+                logging.info(
+                    f"✅ staging_area = {area}, imported = {tdr_load_totals[area]}, expected = {expected_count}")
         else:
-            logging.error(f"{area} has not been imported")
+            logging.error(f"❌ {area} has not been imported")
 
 
 if __name__ == '__main__':

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -48,7 +48,7 @@ def get_load_history(bq_project, dataset, start_date):
     query_job = client.query(query)
 
     # hydrate the rows
-    return list([row for row in query_job])
+    return [row for row in query_job]
 
 
 def parse_manifest_file(manifest_file):
@@ -91,10 +91,10 @@ def verify(start_date, manifest_file, gs_project, bq_project, dataset):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("-s", "--start_date", required=True)
-    parser.add_argument("-f", "--manifest_file", required=True)
-    parser.add_argument("-g", "--gs_project", required=True)
-    parser.add_argument("-b", "--bq_project", required=True)
+    parser.add_argument("-s", "--start-date", required=True)
+    parser.add_argument("-f", "--manifest-file", required=True)
+    parser.add_argument("-g", "--gs-project", required=True)
+    parser.add_argument("-b", "--bq-project", required=True)
     parser.add_argument("-d", "--dataset", required=True)
     args = parser.parse_args()
 

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -14,12 +14,13 @@ import sys
 from urllib.parse import urlparse
 
 from google.cloud import bigquery, storage
+from google.cloud.bigquery.table import Row
 from hca_orchestration.contrib import google as hca_google
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
-def get_expected_load_totals(storage_client, staging_areas):
+def get_expected_load_totals(storage_client, staging_areas) -> dict[str, int]:
     """
     Given a list of GS staging areas, count the files present in each /data subdir
     """
@@ -32,7 +33,7 @@ def get_expected_load_totals(storage_client, staging_areas):
     return expected
 
 
-def get_load_history(bq_project, dataset, start_date):
+def get_load_history(bq_project, dataset, start_date) -> list[Row]:
     client = bigquery.Client(project=bq_project)
 
     # Determine the number of distinct files loaded after the given start date, grouped by staging area
@@ -67,13 +68,13 @@ def get_load_history(bq_project, dataset, start_date):
     return [row for row in query_job]
 
 
-def parse_manifest_file(manifest_file):
+def parse_manifest_file(manifest_file) -> list[str]:
     with open(manifest_file) as manifest:
         # some of the staging areas submitted via the form need slight cleanup
         return [area.rstrip('\n/') for area in manifest]
 
 
-def verify(start_date, manifest_file, gs_project, bq_project, dataset):
+def verify(start_date, manifest_file, gs_project, bq_project, dataset) -> bool:
     logging.info("Parsing manifest and inspecting staging areas...")
     creds = hca_google.get_credentials()
     storage_client = storage.Client(project=gs_project, credentials=creds)

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -15,12 +15,13 @@ from urllib.parse import urlparse
 
 from google.cloud import bigquery, storage
 from google.cloud.bigquery.table import Row
+from google.cloud.storage.client import Client
 from hca_orchestration.contrib import google as hca_google
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
-def get_expected_load_totals(storage_client, staging_areas) -> dict[str, int]:
+def get_expected_load_totals(storage_client: Client, staging_areas: list[str]) -> dict[str, int]:
     """
     Given a list of GS staging areas, count the files present in each /data subdir
     """
@@ -33,7 +34,7 @@ def get_expected_load_totals(storage_client, staging_areas) -> dict[str, int]:
     return expected
 
 
-def get_load_history(bq_project, dataset, start_date) -> list[Row]:
+def get_load_history(bq_project: str, dataset: str, start_date: str) -> list[Row]:
     client = bigquery.Client(project=bq_project)
 
     # Determine the number of distinct files loaded after the given start date, grouped by staging area
@@ -68,13 +69,13 @@ def get_load_history(bq_project, dataset, start_date) -> list[Row]:
     return [row for row in query_job]
 
 
-def parse_manifest_file(manifest_file) -> list[str]:
+def parse_manifest_file(manifest_file: str) -> list[str]:
     with open(manifest_file) as manifest:
         # some of the staging areas submitted via the form need slight cleanup
         return [area.rstrip('\n/') for area in manifest]
 
 
-def verify(start_date, manifest_file, gs_project, bq_project, dataset) -> bool:
+def verify(start_date: str, manifest_file: str, gs_project: str, bq_project: str, dataset: str) -> bool:
     logging.info("Parsing manifest and inspecting staging areas...")
     creds = hca_google.get_credentials()
     storage_client = storage.Client(project=gs_project, credentials=creds)

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -42,13 +42,13 @@ def get_load_history(bq_project, dataset, start_date):
                     FROM `datarepo_{dataset}.datarepo_load_history` dlh
                     LEFT JOIN `datarepo_{dataset}.sequence_file` sf
                     ON sf.file_id = dlh.file_id
-                    LEFT JOIN `broad-datarepo-terra-prod-hca2.datarepo_hca_prod_20201120_dcp2.analysis_file` af
+                    LEFT JOIN `datarepo_{dataset}.analysis_file` af
                     ON af.file_id = dlh.file_id
-                    LEFT JOIN `broad-datarepo-terra-prod-hca2.datarepo_hca_prod_20201120_dcp2.reference_file` rf
+                    LEFT JOIN `datarepo_{dataset}.reference_file` rf
                     ON rf.file_id = dlh.file_id
-                    LEFT JOIN `broad-datarepo-terra-prod-hca2.datarepo_hca_prod_20201120_dcp2.supplementary_file` supf
+                    LEFT JOIN `datarepo_{dataset}.supplementary_file` supf
                     ON supf.file_id = dlh.file_id
-                    LEFT JOIN `broad-datarepo-terra-prod-hca2.datarepo_hca_prod_20201120_dcp2.image_file` imgf
+                    LEFT JOIN `datarepo_{dataset}.image_file` imgf
                     ON imgf.file_id = dlh.file_id
                     WHERE load_time >= '{start_date}'
                     AND state = 'succeeded'

--- a/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/dagster_orchestration/hca_manage/verify_release_manifest.py
@@ -109,7 +109,8 @@ def verify(start_date, manifest_file, gs_project, bq_project, dataset):
             logging.error(f"❌ {area} has not been imported")
             success = False
     logging.info('-' * 80)
-    logging.info(f"Total files staged = {total_expected_count}, total files loaded = {total_loaded_count}")
+    logging.info(
+        f"Total staging areas = {len(expected_load_totals.keys())}, total files staged = {total_expected_count}, total files loaded = {total_loaded_count}")
     return success
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/google.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/google.py
@@ -1,10 +1,16 @@
 import google.auth
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+
+
+def get_credentials() -> Credentials:
+    creds, _ = google.auth.default()
+    return creds
 
 
 def default_google_access_token() -> str:
     # get token for google-based auth use, assumes application default credentials work for specified environment
-    credentials, _ = google.auth.default()
+    credentials = get_credentials()
     credentials.refresh(Request())
 
     return credentials.token  # type: ignore # (unannotated library)


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1648)
We need a script to check the data loaded as part of a release versus the "manifest" of staging areas submitted by wranglers.

## This PR
* Creates a simple script that compares the load history as recorded in TDR vs the set of files in the staging areas provided in the manifest.

