### PR TITLE
Created tests for HCA argo workflows

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
@@ -1,0 +1,219 @@
+import unittest
+
+from unittest.mock import MagicMock, patch, call
+from typing import Generator, TypeVar
+from collections.abc import Iterable
+from datetime import datetime
+from dateutil.tz import tzlocal
+
+from hca_orchestration.contrib.argo_workflows import ExtendedArgoWorkflow, generate_argo_archived_workflows_client, ArgoFetchListOperation, ArgoArchivedWorkflowsClient
+from argo.workflows.client.models import V1alpha1Workflow, V1ObjectMeta, V1alpha1WorkflowSpec, V1alpha1Arguments, V1alpha1Parameter,\
+    V1alpha1WorkflowStatus
+
+
+# the argo workflows api produces this abominable nested set of classes for each workflow,
+# so we build one from simple params here to keep our tests lean
+def mock_argo_workflow(name, uid, status, finished_at=datetime.now(tz=tzlocal()), params={}):
+    return V1alpha1Workflow(
+        metadata=V1ObjectMeta(
+            name=name,
+            uid=uid,
+        ),
+        spec=V1alpha1WorkflowSpec(
+            arguments=V1alpha1Arguments(
+                parameters=[
+                    V1alpha1Parameter(name=k, value=v)
+                    for k, v in params.items()
+                ]
+            )
+        ),
+        status=V1alpha1WorkflowStatus(
+            phase=status,
+            finished_at=finished_at,
+        )
+    )
+
+
+def extend_workflow(workflow: V1alpha1Workflow) -> ExtendedArgoWorkflow:
+    return ExtendedArgoWorkflow(workflow, argo_url='https://nonexistentsite.test', access_token='token')
+
+
+class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
+
+    def test__pull_paginated_results_api_function_no_continue_results_one_call(self):
+        client = ArgoArchivedWorkflowsClient("https://zombo.com", "tokentokentoken")
+        archived_workflows = [
+            mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
+            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', params={
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+            mock_argo_workflow('import-hca-total-cdef', 'abc345uid', 'Succeeded', params={
+                'data-repo-name': 'datarepo_dataset2'
+            }),
+        ]
+
+        test_mock = MagicMock()
+        test_mock.items = archived_workflows
+        test_mock.metadata._continue = None
+
+        with patch('argo.workflows.client.ArchivedWorkflowServiceApi.list_archived_workflows',
+                   return_value=test_mock) as mock_list_archived_workflows:
+            list_results = list(client._pull_paginated_results(mock_list_archived_workflows))
+            self.assertEqual(list_results, archived_workflows)
+            mock_list_archived_workflows.assert_called_once()
+
+    def test__pull_paginated_results_api_function_one_continue_results_two_calls(self):
+        client = ArgoArchivedWorkflowsClient("https://zombo.com", "tokentokentoken")
+        archived_workflows = [
+            mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
+            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', params={
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+            mock_argo_workflow('import-hca-total-cdef', 'abc345uid', 'Succeeded', params={
+                'data-repo-name': 'datarepo_dataset2'
+            }),
+        ]
+
+        test_mock = MagicMock()
+        test_mock.items = archived_workflows
+        test_mock.metadata._continue = "next_page"
+
+        archived_workflows_2 = [
+            mock_argo_workflow('import-hca-total-page2', 'page2uid', 'Supsneeded', params={
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+        ]
+
+        test_mock2 = MagicMock()
+        test_mock2.items = archived_workflows_2
+        test_mock2.metadata._continue = None
+
+        def get_page(list_options_continue=None):
+            if list_options_continue is None:
+                return test_mock
+
+            if list_options_continue == "next_page":
+                return test_mock2
+
+        with patch('argo.workflows.client.ArchivedWorkflowServiceApi.list_archived_workflows',
+                   side_effect=get_page) as mock_list_archived_workflows:
+            list_results = list(client._pull_paginated_results(mock_list_archived_workflows))
+            self.assertEqual(list_results, archived_workflows + archived_workflows_2)
+            self.assertEqual(mock_list_archived_workflows.call_count, 2)
+
+            mock_list_archived_workflows.assert_has_calls([call(), call(list_options_continue="next_page")])
+
+    def test__pull_paginated_results_api_function_multiple_continues_results_multiple_calls(self):
+        client = ArgoArchivedWorkflowsClient("https://zombo.com", "tokentokentoken")
+        archived_workflows = [
+            mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
+            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', params={
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+            mock_argo_workflow('import-hca-total-cdef', 'abc345uid', 'Succeeded', params={
+                'data-repo-name': 'datarepo_dataset2'
+            }),
+        ]
+
+        test_mock = MagicMock()
+        test_mock.items = archived_workflows
+        test_mock.metadata._continue = "page2"
+
+        archived_workflows_2 = [
+            mock_argo_workflow('import-hca-total-page2', 'page2uid', 'Supsneeded', params={
+                'data-repo-name': 'datarepo_dataset1'
+            }),
+        ]
+
+        test_mock2 = MagicMock()
+        test_mock2.items = archived_workflows_2
+        test_mock2.metadata._continue = "page3"
+
+        archived_workflows_3 = [
+            mock_argo_workflow('import-hca-1', '12345', 'Succeeded', params={
+                'data-name': 'dataset',
+                'test': 'data'
+            }),
+            mock_argo_workflow('hca-data', 'u123id', 'Succeeded'),
+        ]
+
+        test_mock3 = MagicMock()
+        test_mock3.items = archived_workflows_3
+        test_mock3.metadata._continue = "page4"
+
+        archived_workflows_4 = [
+            mock_argo_workflow('104', 'uid', 'Succeeded', params={
+                'dataset': 'data'
+            }),
+        ]
+
+        test_mock4 = MagicMock()
+        test_mock4.items = archived_workflows_4
+        test_mock4.metadata._continue = None
+
+        def get_page(list_options_continue=None):
+            if list_options_continue is None:
+                return test_mock
+
+            if list_options_continue == "page2":
+                return test_mock2
+
+            if list_options_continue == "page3":
+                return test_mock3
+
+            if list_options_continue == "page4":
+                return test_mock4
+
+        with patch('argo.workflows.client.ArchivedWorkflowServiceApi.list_archived_workflows',
+                   side_effect=get_page) as mock_list_archived_workflows:
+            list_results = list(client._pull_paginated_results(mock_list_archived_workflows))
+            self.assertEqual(list_results, archived_workflows + archived_workflows_2 + archived_workflows_3 +
+                             archived_workflows_4)
+            self.assertEqual(mock_list_archived_workflows.call_count, 4)
+            mock_list_archived_workflows.assert_has_calls([call(), call(list_options_continue="page2"),
+                                                           call(list_options_continue="page3"),
+                                                           call(list_options_continue="page4")])
+
+    def test_inflate_one_workflow_one_call(self):
+        v1alphaworkflow_mock = mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Succeeded', params={
+            'data-repo-name': 'datarepo_dataset1'
+        })
+
+        workflow = extend_workflow(v1alphaworkflow_mock)
+
+        with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClient.get_archived_workflow',
+                   return_value=v1alphaworkflow_mock) as mock_get_archived_workflow:
+            workflow.inflate()
+            mock_get_archived_workflow.assert_called_once_with(workflow.metadata.uid)
+            workflow.inflate()
+            mock_get_archived_workflow.assert_called_once_with(workflow.metadata.uid)
+
+    def test_params_dict_workflow_info_dict_proper_values(self):
+        archived_workflows = [
+            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Succeeded', params={
+                'data-repo-name': 'datarepo_dataset1',
+                'name': 'value',
+                'testing': 'data',
+                '1023_3': 'e5Qss'
+            }),
+            mock_argo_workflow('hca_import', 'randomuid', 'Succeeded', params={
+                'dataset_name': 'data'
+            }),
+            mock_argo_workflow('hca_import', 'randomuid', 'Succeeded'),
+        ]
+
+        dict0 = {'data-repo-name': 'datarepo_dataset1',
+                 'name': 'value',
+                 'testing': 'data',
+                 '1023_3': 'e5Qss'}
+        dict1 = {
+            'dataset_name': 'data'
+        }
+
+        workflow0 = extend_workflow(archived_workflows[0])
+        workflow1 = extend_workflow(archived_workflows[1])
+        workflow2 = extend_workflow(archived_workflows[2])
+
+        self.assertEqual(workflow0.params_dict(), dict0)
+        self.assertEqual(workflow1.params_dict(), dict1)
+        self.assertEqual(workflow2.params_dict(), {})

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
@@ -132,7 +132,7 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
                 "page4": page_four_response
             }[list_options_continue]
 
-            list_results: list(Iterator[V1alpha1Workflow]) = list(self.client._pull_paginated_results(get_page()))
+            list_results: list[Iterator[V1alpha1Workflow]] = list(self.client._pull_paginated_results(get_page()))
             self.assertEqual(list_results,
                              workflows_on_page_one +
                              workflows_on_page_two +

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
@@ -1,7 +1,7 @@
 import unittest
 
 from unittest.mock import MagicMock, patch, call
-from typing import Generator, TypeVar, Optional
+from typing import Generator, TypeVar, Optional, Iterator
 from collections.abc import Iterable
 
 from hca_orchestration.contrib.argo_workflows import ExtendedArgoWorkflow, generate_argo_archived_workflows_client, \
@@ -132,7 +132,7 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
                 "page4": page_four_response
             }[list_options_continue]
 
-            list_results = list(self.client._pull_paginated_results(get_page()))
+            list_results: list(Iterator[V1alpha1Workflow]) = list(self.client._pull_paginated_results(get_page()))
             self.assertEqual(list_results,
                              workflows_on_page_one +
                              workflows_on_page_two +

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/contrib/test_argo_workflows.py
@@ -10,25 +10,22 @@ from argo.workflows.client.models import V1alpha1Workflow, V1ObjectMeta, V1alpha
     V1alpha1Parameter, \
     V1alpha1WorkflowStatus
 
-from hca_orchestration.tests.support.mock_workflows import mock_argo_workflow
-
-
-def extend_workflow(workflow: V1alpha1Workflow) -> ExtendedArgoWorkflow:
-    return ExtendedArgoWorkflow(workflow, argo_url='https://nonexistentsite.test', access_token='token')
+from hca_orchestration.tests.support.mock_workflows import mock_argo_workflow, extend_workflow
 
 
 class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
     def setUp(self):
         self.client = ArgoArchivedWorkflowsClient("https://zombo.com", "tokentokentoken")
 
-    def workflows_to_page_of_results(self, archived_workflows: [], next_page: Optional[str]):
+    def workflows_to_page_of_results(
+            self, archived_workflows: list[V1alpha1Workflow], next_page: Optional[str]) -> MagicMock:
         results_page = MagicMock()
         results_page.items = archived_workflows
         results_page.metadata._continue = next_page
         return results_page
 
     def test__pull_paginated_results_api_function_no_continue_results_one_call(self):
-        list_containing_3_V1alpha1Workflows = [
+        workflows_on_page_one = [
             mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
             mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', params={
                 'data-repo-name': 'datarepo_dataset1'
@@ -38,16 +35,16 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
             }),
         ]
 
-        archived_workflow_list = self.workflows_to_page_of_results(list_containing_3_V1alpha1Workflows, None)
+        archived_workflow_list = self.workflows_to_page_of_results(workflows_on_page_one, None)
 
         with patch('argo.workflows.client.ArchivedWorkflowServiceApi.list_archived_workflows',
                    return_value=archived_workflow_list) as mock_list_archived_workflows:
             list_results = list(self.client._pull_paginated_results(mock_list_archived_workflows))
-            self.assertEqual(list_results, list_containing_3_V1alpha1Workflows)
+            self.assertEqual(list_results, workflows_on_page_one)
             mock_list_archived_workflows.assert_called_once()
 
     def test__pull_paginated_results_api_function_one_continue_results_two_calls(self):
-        list_containing_3_V1alpha1Workflows = [
+        workflows_on_page_one = [
             mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
             mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', params={
                 'data-repo-name': 'datarepo_dataset1'
@@ -57,35 +54,35 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
             }),
         ]
 
-        archived_workflow_list_3_workflows = self.workflows_to_page_of_results(list_containing_3_V1alpha1Workflows,
-                                                                               "next_page")
+        page_one_response = self.workflows_to_page_of_results(workflows_on_page_one,
+                                                              "next_page")
 
-        list_containing_1_V1alpha1Workflows = [
+        workflows_on_page_two = [
             mock_argo_workflow('import-hca-total-page2', 'page2uid', 'Supsneeded', params={
                 'data-repo-name': 'datarepo_dataset1'
             }),
         ]
 
-        archived_workflow_list_1_workflows = self.workflows_to_page_of_results(list_containing_1_V1alpha1Workflows,
-                                                                               None)
+        page_two_response = self.workflows_to_page_of_results(workflows_on_page_two,
+                                                              None)
 
         def get_page(list_options_continue=None):
             if list_options_continue is None:
-                return archived_workflow_list_3_workflows
+                return page_one_response
 
             if list_options_continue == "next_page":
-                return archived_workflow_list_1_workflows
+                return page_two_response
 
         with patch('argo.workflows.client.ArchivedWorkflowServiceApi.list_archived_workflows',
                    side_effect=get_page) as mock_list_archived_workflows:
             list_results = list(self.client._pull_paginated_results(mock_list_archived_workflows))
-            self.assertEqual(list_results, list_containing_3_V1alpha1Workflows + list_containing_1_V1alpha1Workflows)
+            self.assertEqual(list_results, workflows_on_page_one + workflows_on_page_two)
             self.assertEqual(mock_list_archived_workflows.call_count, 2)
 
             mock_list_archived_workflows.assert_has_calls([call(), call(list_options_continue="next_page")])
 
     def test__pull_paginated_results_api_function_multiple_continues_results_multiple_calls(self):
-        list_containing_3_V1alpha1Workflows = [
+        workflows_on_page_one = [
             mock_argo_workflow('import-hca-total-defg', 'abc123uid', 'Succeeded'),
             mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Supsneeded', params={
                 'data-repo-name': 'datarepo_dataset1'
@@ -95,19 +92,19 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
             }),
         ]
 
-        archived_workflow_list_3_workflows = self.workflows_to_page_of_results(list_containing_3_V1alpha1Workflows,
-                                                                               "page2")
+        page_one_response = self.workflows_to_page_of_results(workflows_on_page_one,
+                                                              "page2")
 
-        list_containing_1_V1alpha1Workflows = [
+        workflows_on_page_two = [
             mock_argo_workflow('import-hca-total-page2', 'page2uid', 'Supsneeded', params={
                 'data-repo-name': 'datarepo_dataset1'
             }),
         ]
 
-        archived_workflow_list_1_workflows = self.workflows_to_page_of_results(list_containing_1_V1alpha1Workflows,
-                                                                               "page3")
+        page_two_response = self.workflows_to_page_of_results(workflows_on_page_two,
+                                                              "page3")
 
-        list_containing_2_V1alpha1Workflows = [
+        workflows_on_page_three = [
             mock_argo_workflow('import-hca-1', '12345', 'Succeeded', params={
                 'data-name': 'dataset',
                 'test': 'data'
@@ -115,29 +112,32 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
             mock_argo_workflow('hca-data', 'u123id', 'Succeeded'),
         ]
 
-        archived_workflow_list_2_workflows = self.workflows_to_page_of_results(list_containing_2_V1alpha1Workflows,
-                                                                               "page4")
+        page_three_response = self.workflows_to_page_of_results(workflows_on_page_three,
+                                                                "page4")
 
-        list_containing_0_V1alpha1Workflows = [
+        workflows_on_page_four = [
+            mock_argo_workflow('hca-import', 'uid', 'Succeeded', params={
+                'testing_data': 'dataset'
+            }),
         ]
 
-        archived_workflow_list_0_workflows = self.workflows_to_page_of_results(list_containing_0_V1alpha1Workflows,
-                                                                               None)
+        page_four_response = self.workflows_to_page_of_results(workflows_on_page_four,
+                                                               None)
 
         def get_page(list_options_continue=None):
             {
-                None: archived_workflow_list_3_workflows,
-                "page2": archived_workflow_list_1_workflows,
-                "page3": archived_workflow_list_2_workflows,
-                "page4": archived_workflow_list_0_workflows
+                None: page_one_response,
+                "page2": page_two_response,
+                "page3": page_three_response,
+                "page4": page_four_response
             }[list_options_continue]
 
             list_results = list(self.client._pull_paginated_results(get_page()))
             self.assertEqual(list_results,
-                             list_containing_3_V1alpha1Workflows +
-                             list_containing_1_V1alpha1Workflows +
-                             list_containing_2_V1alpha1Workflows +
-                             list_containing_0_V1alpha1Workflows)
+                             workflows_on_page_one +
+                             workflows_on_page_two +
+                             workflows_on_page_three +
+                             workflows_on_page_four)
             self.assertEqual(list_results.call_count, 4)
             list_results.assert_has_calls([call(),
                                            call(list_options_continue="page2"),
@@ -145,14 +145,14 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
                                            call(list_options_continue="page4")])
 
     def test_inflate_one_workflow_one_call(self):
-        v1alphaworkflow_mock = mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Succeeded', params={
+        mock_inflated_workflow = mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Succeeded', params={
             'data-repo-name': 'datarepo_dataset1'
         })
 
-        workflow = extend_workflow(v1alphaworkflow_mock)
+        workflow = extend_workflow(mock_inflated_workflow)
 
         with patch('hca_orchestration.contrib.argo_workflows.ArgoArchivedWorkflowsClient.get_archived_workflow',
-                   return_value=v1alphaworkflow_mock) as mock_get_archived_workflow:
+                   return_value=mock_inflated_workflow) as mock_get_archived_workflow:
             workflow.inflate()
             mock_get_archived_workflow.assert_called_once_with(workflow.metadata.uid)
             # Checking that despite inflate called twice, mock_get_archived_workflow is only called once
@@ -160,21 +160,25 @@ class ArgoArchivedWorkflowsClientTestCase(unittest.TestCase):
             mock_get_archived_workflow.assert_called_once_with(workflow.metadata.uid)
 
     def test_params_dict_workflow_info_dict_proper_values(self):
-        dict0 = {'data-repo-name': 'datarepo_dataset1',
-                 'name': 'value',
-                 'testing': 'data',
-                 '1023_3': 'e5Qss'}
-        dict1 = {
+        params_for_argo_workflow_large = {'data-repo-name': 'datarepo_dataset1',
+                                          'name': 'value',
+                                          'testing': 'data',
+                                          '1023_3': 'e5Qss'}
+        params_for_argo_workflow_small = {
             'dataset_name': 'data'
         }
         archived_workflows = [
-            mock_argo_workflow('import-hca-total-abcd', 'abc234uid', 'Succeeded', params=dict0),
-            mock_argo_workflow('hca_import', 'randomuid', 'Succeeded', params=dict1),
+            mock_argo_workflow(
+                'import-hca-total-abcd',
+                'abc234uid',
+                'Succeeded',
+                params=params_for_argo_workflow_large),
+            mock_argo_workflow('hca_import', 'randomuid', 'Succeeded', params=params_for_argo_workflow_small),
             mock_argo_workflow('hca_import', 'randomuid', 'Succeeded'),
         ]
 
         list_workflows = [extend_workflow(workflow) for workflow in archived_workflows]
 
-        self.assertEqual(list_workflows[0].params_dict(), dict0)
-        self.assertEqual(list_workflows[1].params_dict(), dict1)
+        self.assertEqual(list_workflows[0].params_dict(), params_for_argo_workflow_large)
+        self.assertEqual(list_workflows[1].params_dict(), params_for_argo_workflow_small)
         self.assertEqual(list_workflows[2].params_dict(), {})

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/support/mock_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/support/mock_workflows.py
@@ -1,13 +1,18 @@
 from datetime import datetime
 from dateutil.tz import tzlocal
+from typing import Any
+
 from argo.workflows.client.models import V1alpha1Workflow, V1ObjectMeta, V1alpha1WorkflowSpec, V1alpha1Arguments, V1alpha1Parameter, \
     V1alpha1WorkflowStatus
+
+from hca_orchestration.contrib.argo_workflows import ExtendedArgoWorkflow
 
 # the argo workflows api produces this abominable nested set of classes for each workflow,
 # so we build one from simple params here to keep our tests lean
 
 
-def mock_argo_workflow(name, uid, status, finished_at=datetime.now(tz=tzlocal()), params={}):
+def mock_argo_workflow(name: str, uid: str, status: str, finished_at: datetime = datetime.now(
+        tz=tzlocal()), params: dict[str, Any] = {}) -> V1alpha1Workflow:
     return V1alpha1Workflow(
         metadata=V1ObjectMeta(
             name=name,
@@ -26,3 +31,7 @@ def mock_argo_workflow(name, uid, status, finished_at=datetime.now(tz=tzlocal())
             finished_at=finished_at,
         )
     )
+
+
+def extend_workflow(workflow: V1alpha1Workflow) -> ExtendedArgoWorkflow:
+    return ExtendedArgoWorkflow(workflow, argo_url='https://nonexistentsite.test', access_token='token')

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/support/mock_workflows.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/support/mock_workflows.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from dateutil.tz import tzlocal
+from argo.workflows.client.models import V1alpha1Workflow, V1ObjectMeta, V1alpha1WorkflowSpec, V1alpha1Arguments, V1alpha1Parameter, \
+    V1alpha1WorkflowStatus
+
+# the argo workflows api produces this abominable nested set of classes for each workflow,
+# so we build one from simple params here to keep our tests lean
+
+
+def mock_argo_workflow(name, uid, status, finished_at=datetime.now(tz=tzlocal()), params={}):
+    return V1alpha1Workflow(
+        metadata=V1ObjectMeta(
+            name=name,
+            uid=uid,
+        ),
+        spec=V1alpha1WorkflowSpec(
+            arguments=V1alpha1Arguments(
+                parameters=[
+                    V1alpha1Parameter(name=k, value=v)
+                    for k, v in params.items()
+                ]
+            )
+        ),
+        status=V1alpha1WorkflowStatus(
+            phase=status,
+            finished_at=finished_at,
+        )
+    )

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
@@ -12,7 +12,7 @@ from argo.workflows.client.models import V1alpha1Arguments, V1alpha1Parameter, V
 
 from hca_orchestration.contrib.argo_workflows import ExtendedArgoWorkflow, generate_argo_archived_workflows_client
 from hca_orchestration.sensors import ArgoHcaImportCompletionSensor
-from hca_orchestration.tests.support.mock_workflows import mock_argo_workflow
+from hca_orchestration.tests.support.mock_workflows import mock_argo_workflow, extend_workflow
 
 T = TypeVar('T')
 
@@ -21,10 +21,6 @@ T = TypeVar('T')
 def generator(iterable: Iterable[T]) -> Generator[T, None, None]:
     for obj in iterable:
         yield obj
-
-
-def extend_workflow(workflow: V1alpha1Workflow) -> ExtendedArgoWorkflow:
-    return ExtendedArgoWorkflow(workflow, argo_url='https://nonexistentsite.test', access_token='token')
 
 
 class TestArgoWorkflowsClient(unittest.TestCase):

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_sensors.py
@@ -12,7 +12,7 @@ from argo.workflows.client.models import V1alpha1Arguments, V1alpha1Parameter, V
 
 from hca_orchestration.contrib.argo_workflows import ExtendedArgoWorkflow, generate_argo_archived_workflows_client
 from hca_orchestration.sensors import ArgoHcaImportCompletionSensor
-
+from hca_orchestration.tests.support.mock_workflows import mock_argo_workflow
 
 T = TypeVar('T')
 
@@ -21,29 +21,6 @@ T = TypeVar('T')
 def generator(iterable: Iterable[T]) -> Generator[T, None, None]:
     for obj in iterable:
         yield obj
-
-
-# the argo workflows api produces this abominable nested set of classes for each workflow,
-# so we build one from simple params here to keep our tests lean
-def mock_argo_workflow(name, uid, status, finished_at=datetime.now(tz=tzlocal()), params={}):
-    return V1alpha1Workflow(
-        metadata=V1ObjectMeta(
-            name=name,
-            uid=uid,
-        ),
-        spec=V1alpha1WorkflowSpec(
-            arguments=V1alpha1Arguments(
-                parameters=[
-                    V1alpha1Parameter(name=k, value=v)
-                    for k, v in params.items()
-                ]
-            )
-        ),
-        status=V1alpha1WorkflowStatus(
-            phase=status,
-            finished_at=finished_at,
-        )
-    )
 
 
 def extend_workflow(workflow: V1alpha1Workflow) -> ExtendedArgoWorkflow:


### PR DESCRIPTION
## Why
Currently do not have unit tests for Argo client
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1640)

## This PR
Create unit tests without making calls to the Argo API.
