### PR TITLE
Add default scopes to GCloud tokens

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -1,8 +1,5 @@
 name: Master Validation and Release
-on:
-  push:
-    branches:
-      - master
+on: [push]
 jobs:
   master-ci:
     runs-on: ubuntu-latest
@@ -10,12 +7,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Fetch tag history
         run: git fetch --tags
-      - uses: google-github-actions/setup-gcloud@v0.2.1
-        name: Setup gcloud for Dataflow tests
-        with:
-          project_id: ${{ secrets.DEV_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_TEST_KEY }}
-          export_default_credentials: true
+      # - uses: google-github-actions/setup-gcloud@v0.2.1
+      #   name: Setup gcloud for Dataflow tests
+      #   with:
+      #     project_id: ${{ secrets.DEV_PROJECT_ID }}
+      #     service_account_key: ${{ secrets.GCP_TEST_KEY }}
+      #     export_default_credentials: true
       - name: Set up Python 3.9 for dataflow tests
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -33,37 +33,37 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-dev
         working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-      - uses: olafurpg/setup-scala@v10
-        with:
-          java-version: graalvm@20.0.0
-      - name: Check Scala formatting
-        run: sbt scalafmtCheckAll
-      - name: Scala Compile
-        run: sbt Compile/compile Test/compile IntegrationTest/compile
-      - name: Scala Test
-        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      - name: Run Dataflow against test data
-        env:
-          GITHUB_SHA: ${{github.sha}}
-        run: >
-          sbt "hca-transformation-pipeline/run
-                 --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/test_data
-                 --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
-                 --runner=DataflowRunner
-                 --project=broad-dsp-monster-hca-dev
-                 --region=us-central1
-                 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow
-                 --workerMachineType=n1-standard-4
-                 --numWorkers=16
-                 --experiments=shuffle_mode=service"
-      - name: Verify Dataflow output
-        env:
-          GITHUB_SHA: ${{github.sha}}
-        run: >
-          poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected_output -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
-        working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration/hca_manage
-      - name: Publish Scala coverage
-        uses: codecov/codecov-action@v1
+      # - uses: olafurpg/setup-scala@v10
+      #   with:
+      #     java-version: graalvm@20.0.0
+      # - name: Check Scala formatting
+      #   run: sbt scalafmtCheckAll
+      # - name: Scala Compile
+      #   run: sbt Compile/compile Test/compile IntegrationTest/compile
+      # - name: Scala Test
+      #   run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+      # - name: Run Dataflow against test data
+      #   env:
+      #     GITHUB_SHA: ${{github.sha}}
+      #   run: >
+      #     sbt "hca-transformation-pipeline/run
+      #            --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/test_data
+      #            --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
+      #            --runner=DataflowRunner
+      #            --project=broad-dsp-monster-hca-dev
+      #            --region=us-central1
+      #            --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow
+      #            --workerMachineType=n1-standard-4
+      #            --numWorkers=16
+      #            --experiments=shuffle_mode=service"
+      # - name: Verify Dataflow output
+      #   env:
+      #     GITHUB_SHA: ${{github.sha}}
+      #   run: >
+      #     poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected_output -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
+      #   working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration/hca_manage
+      # - name: Publish Scala coverage
+      #   uses: codecov/codecov-action@v1
       - uses: google-github-actions/setup-gcloud@v0.2.1
         name: Setup gcloud for pushing Docker images
         with:
@@ -72,8 +72,8 @@ jobs:
           export_default_credentials: true
       - name: Setup GCR auth
         run: gcloud auth configure-docker --quiet us.gcr.io
-      - name: Push Scala Dataflow Docker image
-        run: sbt publish
+      # - name: Push Scala Dataflow Docker image
+      #   run: sbt publish
       - name: Get artifact slug
         id: get-artifact-slug
         run: 'echo ::set-output name=slug::$(git rev-parse --short "$GITHUB_SHA")'

--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -1,5 +1,8 @@
 name: Master Validation and Release
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   master-ci:
     runs-on: ubuntu-latest
@@ -7,12 +10,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Fetch tag history
         run: git fetch --tags
-      # - uses: google-github-actions/setup-gcloud@v0.2.1
-      #   name: Setup gcloud for Dataflow tests
-      #   with:
-      #     project_id: ${{ secrets.DEV_PROJECT_ID }}
-      #     service_account_key: ${{ secrets.GCP_TEST_KEY }}
-      #     export_default_credentials: true
+      - uses: google-github-actions/setup-gcloud@v0.2.1
+        name: Setup gcloud for Dataflow tests
+        with:
+          project_id: ${{ secrets.DEV_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_TEST_KEY }}
+          export_default_credentials: true
       - name: Set up Python 3.9 for dataflow tests
         uses: actions/setup-python@v2
         with:
@@ -33,37 +36,37 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-dev
         working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
-      # - uses: olafurpg/setup-scala@v10
-      #   with:
-      #     java-version: graalvm@20.0.0
-      # - name: Check Scala formatting
-      #   run: sbt scalafmtCheckAll
-      # - name: Scala Compile
-      #   run: sbt Compile/compile Test/compile IntegrationTest/compile
-      # - name: Scala Test
-      #   run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      # - name: Run Dataflow against test data
-      #   env:
-      #     GITHUB_SHA: ${{github.sha}}
-      #   run: >
-      #     sbt "hca-transformation-pipeline/run
-      #            --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/test_data
-      #            --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
-      #            --runner=DataflowRunner
-      #            --project=broad-dsp-monster-hca-dev
-      #            --region=us-central1
-      #            --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow
-      #            --workerMachineType=n1-standard-4
-      #            --numWorkers=16
-      #            --experiments=shuffle_mode=service"
-      # - name: Verify Dataflow output
-      #   env:
-      #     GITHUB_SHA: ${{github.sha}}
-      #   run: >
-      #     poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected_output -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
-      #   working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration/hca_manage
-      # - name: Publish Scala coverage
-      #   uses: codecov/codecov-action@v1
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: graalvm@20.0.0
+      - name: Check Scala formatting
+        run: sbt scalafmtCheckAll
+      - name: Scala Compile
+        run: sbt Compile/compile Test/compile IntegrationTest/compile
+      - name: Scala Test
+        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+      - name: Run Dataflow against test data
+        env:
+          GITHUB_SHA: ${{github.sha}}
+        run: >
+          sbt "hca-transformation-pipeline/run
+                 --inputPrefix=gs://broad-dsp-monster-hca-dev-test-storage/integration/ebi_small/test_data
+                 --outputPrefix=gs://broad-dsp-monster-hca-dev-temp-storage/integration/output_${GITHUB_SHA}
+                 --runner=DataflowRunner
+                 --project=broad-dsp-monster-hca-dev
+                 --region=us-central1
+                 --tempLocation=gs://broad-dsp-monster-hca-dev-temp-storage/dataflow
+                 --workerMachineType=n1-standard-4
+                 --numWorkers=16
+                 --experiments=shuffle_mode=service"
+      - name: Verify Dataflow output
+        env:
+          GITHUB_SHA: ${{github.sha}}
+        run: >
+          poetry run python diff_dirs.py -p broad-dsp-monster-hca-dev -sb broad-dsp-monster-hca-dev-test-storage -sp integration/ebi_small/expected_output -tb broad-dsp-monster-hca-dev-temp-storage -tp "integration/output_${GITHUB_SHA}"
+        working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration/hca_manage
+      - name: Publish Scala coverage
+        uses: codecov/codecov-action@v1
       - uses: google-github-actions/setup-gcloud@v0.2.1
         name: Setup gcloud for pushing Docker images
         with:
@@ -72,8 +75,8 @@ jobs:
           export_default_credentials: true
       - name: Setup GCR auth
         run: gcloud auth configure-docker --quiet us.gcr.io
-      # - name: Push Scala Dataflow Docker image
-      #   run: sbt publish
+      - name: Push Scala Dataflow Docker image
+        run: sbt publish
       - name: Get artifact slug
         id: get-artifact-slug
         run: 'echo ::set-output name=slug::$(git rev-parse --short "$GITHUB_SHA")'

--- a/ops/helmfiles/dagster/forward_ports.sh
+++ b/ops/helmfiles/dagster/forward_ports.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 # This script forwards port 8080 to the Kubernetes cluster running our Dagster install so you can access
 # the Dagit dashboard from your machine.
+ENV=${1:-dev}
+
+echo $ENV
+
+if [ "$ENV" == "prod" ]; then
+	gcloud container clusters get-credentials hca-cluster --project mystical-slate-284720 --region us-central1-c
+else
+	gcloud container clusters get-credentials hca-cluster --project broad-dsp-monster-hca-dev --region us-central1-c
+fi
+
 export DAGIT_POD_NAME=$(kubectl get pods --namespace dagster -l "app.kubernetes.io/name=dagster,app.kubernetes.io/instance=monster,component=dagit" -o jsonpath="{.items[0].metadata.name}")
 kubectl --namespace dagster port-forward $DAGIT_POD_NAME 8080:80

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/google.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/google.py
@@ -2,9 +2,11 @@ import google.auth
 from google.auth.transport.requests import AuthorizedSession, Request
 from google.oauth2.credentials import Credentials
 
+DEFAULT_SCOPES = ['openid', 'email', 'profile']
+
 
 def get_credentials() -> Credentials:
-    creds, _ = google.auth.default()
+    creds, _ = google.auth.default(scopes=DEFAULT_SCOPES)
     return creds
 
 

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/google.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/google.py
@@ -2,7 +2,7 @@ import google.auth
 from google.auth.transport.requests import AuthorizedSession, Request
 from google.oauth2.credentials import Credentials
 
-DEFAULT_SCOPES = ['openid', 'email', 'profile']
+DEFAULT_SCOPES = ['openid', 'email', 'profile', 'https://www.googleapis.com/auth/cloud-platform']
 
 
 def get_credentials() -> Credentials:


### PR DESCRIPTION
## Why

Our access tokens aren't valid to Jade anymore because they have no associated scopes. This change configures tokens with the four scopes (basically just "identify ourselves") that Jade expects for its API calls.

It also includes an unrelated change to the `forward_ports.sh` script to also handle pointing us at the correct Kubernetes cluster.