### PR TITLE
Fix Dagit config resource ref in snapshot slack hooks

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/config/resources/live_slack_client/global.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/resources/live_slack_client/global.yaml
@@ -1,1 +1,3 @@
 channel: "#monster-ci"
+token:
+  env: SLACK_TOKEN

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -69,7 +69,7 @@ def snapshot_start_notification(context: HookContext) -> None:
     message = (
         f"Cutting snapshot '{context.resources.snapshot_config.snapshot_name}' "
         f"for dataset '{context.resources.snapshot_config.dataset_name}'.\n"
-        f"<{context.resources.dagit.run_url(context.run_id)}|View in Dagit>"
+        f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
     context.resources.slack.send_message(message)
@@ -82,7 +82,7 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
     message = (
         f"FAILED to cut snapshot '{context.resources.snapshot_config.snapshot_name}' "
         f"for dataset '{context.resources.snapshot_config.dataset_name}!\n"
-        f"<{context.resources.dagit.run_url(context.run_id)}|View in Dagit>"
+        f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
     context.resources.slack.send_message(message)
@@ -95,7 +95,7 @@ def message_for_snapshot_done(context: HookContext) -> None:
     message = (
         f"COMPLETED snapshot '{context.resources.snapshot_config.snapshot_name}' "
         f"for dataset '{context.resources.snapshot_config.dataset_name}'.\n"
-        f"<{context.resources.dagit.run_url(context.run_id)}|View in Dagit>"
+        f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
     context.resources.slack.send_message(message)

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/slack.py
@@ -1,10 +1,8 @@
 from dataclasses import dataclass
 
 import slack
-from dagster import configured, DagsterLogManager, resource, String, StringSource
+from dagster import DagsterLogManager, resource, String, StringSource
 from dagster.core.execution.context.init import InitResourceContext
-
-from hca_orchestration.support.typing import DagsterConfigDict
 
 
 @dataclass
@@ -33,20 +31,8 @@ class LiveSlackClient:
     'channel': String,
     'token': StringSource,
 })
-def untokened_live_slack_client(init_context: InitResourceContext) -> LiveSlackClient:
+def live_slack_client(init_context: InitResourceContext) -> LiveSlackClient:
     return LiveSlackClient(
         slack.WebClient(init_context.resource_config['token']),
         init_context.resource_config['channel'],
     )
-
-
-# this can't be fully configured using preconfigure_for_mode, since SLACK_TOKEN is a secret
-@configured(untokened_live_slack_client, {'channel': String})
-def live_slack_client(config: DagsterConfigDict) -> DagsterConfigDict:
-    return {
-        'token': {'env': 'SLACK_TOKEN'},
-        **config,
-    }
-
-
-live_slack_client.__name__ = 'live_slack_client'

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/stage_data.py
@@ -1,6 +1,6 @@
 import re
 
-from dagster import solid, InputDefinition, Nothing, String, Int, OutputDefinition
+from dagster import solid, InputDefinition, Nothing, String, Int
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 from google.cloud.bigquery import Dataset
 


### PR DESCRIPTION
Also moves the secret env config for the Slack resource into our config files and removes an unused import.