### PR TITLE
Make primitive subtypes passable via config

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/common.py
+++ b/orchestration/dagster_orchestration/hca_manage/common.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 import sys
 from typing import NoReturn, TextIO
 
+from dagster import make_python_type_usable_as_dagster_type
+from dagster.core.types.dagster_type import String as DagsterString
+
 from dagster_utils.contrib.google import default_google_access_token
 from data_repo_client import ApiClient, Configuration, RepositoryApi
 
@@ -11,6 +14,9 @@ from data_repo_client import ApiClient, Configuration, RepositoryApi
 # alias for str to make the return type for jade API calls a little clearer
 class JobId(str):
     pass
+
+
+make_python_type_usable_as_dagster_type(JobId, DagsterString)
 
 
 @dataclass

--- a/orchestration/dagster_orchestration/hca_orchestration/support/typing.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/support/typing.py
@@ -7,9 +7,8 @@ from dagster import make_python_type_usable_as_dagster_type
 from dagster.core.types.dagster_type import String as DagsterString
 
 
-
 class HcaScratchDatasetName(str):
     pass
 
 
-make_python_type_usable_as_dagster_type(HcaStagingDatasetName, DagsterString)
+make_python_type_usable_as_dagster_type(HcaScratchDatasetName, DagsterString)

--- a/orchestration/dagster_orchestration/hca_orchestration/support/typing.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/support/typing.py
@@ -3,6 +3,11 @@ Complex type signatures that appear multiple times throughout the code
 base can live here, for easy reference and descriptive naming.
 """
 
+from dagster import make_python_type_usable_as_dagster_type
+
 
 class HcaScratchDatasetName(str):
     pass
+
+
+make_python_type_usable_as_dagster_type(HcaStagingDatasetName, str)

--- a/orchestration/dagster_orchestration/hca_orchestration/support/typing.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/support/typing.py
@@ -4,10 +4,12 @@ base can live here, for easy reference and descriptive naming.
 """
 
 from dagster import make_python_type_usable_as_dagster_type
+from dagster.core.types.dagster_type import String as DagsterString
+
 
 
 class HcaScratchDatasetName(str):
     pass
 
 
-make_python_type_usable_as_dagster_type(HcaStagingDatasetName, str)
+make_python_type_usable_as_dagster_type(HcaStagingDatasetName, DagsterString)


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1752)

## This PR

* Makes the simple primitive subtypes passable in run config, so you can stub them out in Dagit. This lets us run pipelines without needing to necessarily start at the beginning for inputs like these.