### PR TITLE
Add config for storing intermediate Dagster outputs in GCS

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/config/resources/gcs_pickle_io_manager/dev.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/resources/gcs_pickle_io_manager/dev.yaml
@@ -1,0 +1,1 @@
+gcs_bucket: broad-dsp-monster-hca-dev-dagster-storage

--- a/orchestration/dagster_orchestration/hca_orchestration/config/resources/gcs_pickle_io_manager/global.yml
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/resources/gcs_pickle_io_manager/global.yml
@@ -1,0 +1,1 @@
+gcs_prefix: runs/solid-outputs-

--- a/orchestration/dagster_orchestration/hca_orchestration/config/resources/gcs_pickle_io_manager/prod.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/resources/gcs_pickle_io_manager/prod.yaml
@@ -1,0 +1,1 @@
+gcs_bucket: broad-dsp-monster-hca-prod-dagster-storage

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -1,6 +1,9 @@
 from dagster import ModeDefinition, pipeline, success_hook, failure_hook
 from dagster.core.execution.context.system import HookContext
 
+from dagster_gcp.gcs import gcs_pickle_io_manager
+
+from dagster_utils.resources.google_storage import google_storage_client
 from dagster_utils.resources.jade_data_repo import jade_data_repo_client, noop_data_repo_client
 from dagster_utils.resources.sam import sam_client, noop_sam_client
 from dagster_utils.resources.slack import console_slack_client, live_slack_client
@@ -16,7 +19,9 @@ prod_mode = ModeDefinition(
     name="prod",
     resource_defs={
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "prod"),
+        "gcs": google_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "prod"),
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "prod"),
         "sam_client": preconfigure_resource_for_mode(sam_client, "prod"),
         "slack": preconfigure_resource_for_mode(live_slack_client, "prod"),
         "snapshot_config": snapshot_creation_config,
@@ -28,7 +33,9 @@ dev_mode = ModeDefinition(
     name="dev",
     resource_defs={
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+        "gcs": google_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
         # we don't want to actually hit sam and make a snapshot public
         # unless we're running in prod
         "sam_client": noop_sam_client,
@@ -42,6 +49,7 @@ local_mode = ModeDefinition(
     name="local",
     resource_defs={
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+        "gcs": google_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
         "sam_client": noop_sam_client,
         "slack": preconfigure_resource_for_mode(live_slack_client, "local"),

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
@@ -1,5 +1,7 @@
 from dagster import ModeDefinition, pipeline
 
+from dagster_gcp.gcs import gcs_pickle_io_manager
+
 from dagster_utils.resources.beam import dataflow_beam_runner, local_beam_runner, test_beam_runner
 from dagster_utils.resources.bigquery import bigquery_client, noop_bigquery_client
 from dagster_utils.resources.google_storage import google_storage_client, mock_storage_client
@@ -17,9 +19,10 @@ prod_mode = ModeDefinition(
     name="prod",
     resource_defs={
         "beam_runner": preconfigure_resource_for_mode(dataflow_beam_runner, "prod"),
-        "storage_client": google_storage_client,
-        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "prod"),
         "bigquery_client": bigquery_client,
+        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "prod"),
+        "gcs": google_storage_client,
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "prod"),
         "load_tag": load_tag,
         "scratch_config": scratch_config,
     }
@@ -29,9 +32,10 @@ dev_mode = ModeDefinition(
     name="dev",
     resource_defs={
         "beam_runner": preconfigure_resource_for_mode(dataflow_beam_runner, "dev"),
-        "storage_client": google_storage_client,
-        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
         "bigquery_client": bigquery_client,
+        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+        "gcs": google_storage_client,
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
         "load_tag": load_tag,
         "scratch_config": scratch_config,
     }
@@ -41,9 +45,10 @@ local_mode = ModeDefinition(
     name="local",
     resource_defs={
         "beam_runner": local_beam_runner,
-        "storage_client": google_storage_client,
-        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
         "bigquery_client": bigquery_client,
+        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+        "gcs": google_storage_client,
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
         "load_tag": load_tag,
         "scratch_config": scratch_config,
     }
@@ -53,7 +58,7 @@ test_mode = ModeDefinition(
     name="test",
     resource_defs={
         "beam_runner": test_beam_runner,
-        "storage_client": mock_storage_client,
+        "gcs": mock_storage_client,
         "data_repo_client": noop_data_repo_client,
         "bigquery_client": noop_bigquery_client,
         "load_tag": load_tag,

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/validate_egress.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/validate_egress.py
@@ -1,5 +1,8 @@
 from dagster import ModeDefinition, pipeline
 
+from dagster_gcp.gcs import gcs_pickle_io_manager
+
+from dagster_utils.resources.google_storage import google_storage_client, mock_storage_client
 from dagster_utils.resources.jade_data_repo import jade_data_repo_client, noop_data_repo_client
 from dagster_utils.resources.slack import console_slack_client, live_slack_client
 
@@ -12,9 +15,11 @@ prod_mode = ModeDefinition(
     name="prod",
     resource_defs={
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "prod"),
-        "slack": preconfigure_resource_for_mode(live_slack_client, "prod"),
+        "gcs": google_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "prod"),
         "hca_dataset_operation_config": hca_dataset_operation_config,
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "prod"),
+        "slack": preconfigure_resource_for_mode(live_slack_client, "prod"),
     }
 )
 
@@ -22,9 +27,11 @@ dev_mode = ModeDefinition(
     name="dev",
     resource_defs={
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
-        "slack": preconfigure_resource_for_mode(live_slack_client, "dev"),
+        "gcs": google_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
         "hca_dataset_operation_config": hca_dataset_operation_config,
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
+        "slack": preconfigure_resource_for_mode(live_slack_client, "dev"),
     }
 )
 
@@ -32,9 +39,11 @@ local_mode = ModeDefinition(
     name="local",
     resource_defs={
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
-        "slack": console_slack_client,
+        "gcs": google_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
         "hca_dataset_operation_config": hca_dataset_operation_config,
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
+        "slack": console_slack_client,
     }
 )
 
@@ -42,9 +51,10 @@ test_mode = ModeDefinition(
     name="test",
     resource_defs={
         "data_repo_client": noop_data_repo_client,
-        "slack": console_slack_client,
+        "gcs": mock_storage_client,
         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "test"),
         "hca_dataset_operation_config": hca_dataset_operation_config,
+        "slack": console_slack_client,
     }
 )
 

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/stage_data.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/stage_data.py
@@ -8,7 +8,7 @@ from hca_orchestration.support.typing import HcaStagingDatasetName
 
 
 @solid(
-    required_resource_keys={"storage_client", "scratch_config"},
+    required_resource_keys={"gcs", "scratch_config"},
 )
 def clear_scratch_dir(context: AbstractComputeExecutionContext) -> int:
     """
@@ -19,7 +19,7 @@ def clear_scratch_dir(context: AbstractComputeExecutionContext) -> int:
     scratch_bucket_name = context.resources.scratch_config.scratch_bucket_name
     scratch_prefix_name = context.resources.scratch_config.scratch_prefix_name
 
-    blobs = context.resources.storage_client.list_blobs(scratch_bucket_name, prefix=f"{scratch_prefix_name}/")
+    blobs = context.resources.gcs.list_blobs(scratch_bucket_name, prefix=f"{scratch_prefix_name}/")
     deletions_count = 0
     for blob in blobs:
         blob.delete()

--- a/orchestration/dagster_orchestration/poetry.lock
+++ b/orchestration/dagster_orchestration/poetry.lock
@@ -280,6 +280,25 @@ docker = ["docker"]
 test = ["astroid (>=2.3.3,<2.5)", "black (==20.8b1)", "coverage (==5.3)", "docker", "flake8 (>=3.7.8)", "freezegun (>=0.3.15)", "grpcio-tools (==1.32.0)", "isort (>=4.3.21,<5)", "mock (==3.0.5)", "protobuf (==3.13.0)", "pylint (==2.6.0)", "pytest-cov (==2.10.1)", "pytest-dependency (==0.5.1)", "pytest-mock (==3.3.1)", "pytest-runner (==5.2)", "pytest-xdist (==2.1.0)", "pytest (==6.1.1)", "responses (>=0.10.0,<0.11.0)", "snapshottest (==0.6.0)", "tox (==3.14.2)", "tox-pip-version (==0.0.7)", "tqdm (==4.48.0)", "yamllint"]
 
 [[package]]
+name = "dagster-gcp"
+version = "0.11.8"
+description = "Package for GCP-specific Dagster framework solid and resource components."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+dagster = "*"
+dagster-pandas = "*"
+google-api-python-client = "<2.0.0"
+google-cloud-bigquery = ">=1.19"
+google-cloud-storage = "*"
+oauth2client = "*"
+
+[package.extras]
+pyarrow = ["pyarrow"]
+
+[[package]]
 name = "dagster-graphql"
 version = "0.11.6"
 description = "The GraphQL frontend to python dagster."
@@ -305,6 +324,18 @@ python-versions = "*"
 dagster = "*"
 dagster-graphql = "*"
 kubernetes = "*"
+
+[[package]]
+name = "dagster-pandas"
+version = "0.11.8"
+description = "Utilities and examples for working with pandas and dagster, an opinionated framework for expressing data pipelines"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+dagster = "*"
+pandas = "*"
 
 [[package]]
 name = "dagster-postgres"
@@ -531,6 +562,22 @@ grpcgcp = ["grpcio-gcp (>=0.2.2)"]
 grpcio-gcp = ["grpcio-gcp (>=0.2.2)"]
 
 [[package]]
+name = "google-api-python-client"
+version = "1.12.8"
+description = "Google API Client Library for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[package.dependencies]
+google-api-core = ">=1.21.0,<2dev"
+google-auth = ">=1.16.0"
+google-auth-httplib2 = ">=0.0.3"
+httplib2 = ">=0.15.0,<1dev"
+six = ">=1.13.0,<2dev"
+uritemplate = ">=3.0.0,<4dev"
+
+[[package]]
 name = "google-auth"
 version = "1.30.0"
 description = "Google Authentication Library"
@@ -548,6 +595,19 @@ six = ">=1.9.0"
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)"]
 pyopenssl = ["pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.1.0"
+description = "Google Authentication Library: httplib2 transport"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+google-auth = "*"
+httplib2 = ">=0.15.0"
+six = "*"
 
 [[package]]
 name = "google-cloud-bigquery"
@@ -759,6 +819,17 @@ python-versions = "*"
 [package.dependencies]
 grpcio = ">=1.37.0"
 protobuf = ">=3.6.0"
+
+[[package]]
+name = "httplib2"
+version = "0.19.1"
+description = "A comprehensive HTTP client library."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyparsing = ">=2.4.2,<3"
 
 [[package]]
 name = "humanfriendly"
@@ -1005,6 +1076,29 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "numpy"
+version = "1.20.3"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "oauth2client"
+version = "4.1.3"
+description = "OAuth 2.0 client library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+httplib2 = ">=0.9.1"
+pyasn1 = ">=0.1.7"
+pyasn1-modules = ">=0.0.5"
+rsa = ">=3.1.4"
+six = ">=1.6.1"
+
+[[package]]
 name = "oauthlib"
 version = "3.1.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1027,6 +1121,22 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
+
+[[package]]
+name = "pandas"
+version = "1.2.4"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.7.1"
+
+[package.dependencies]
+numpy = ">=1.16.5"
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.3"
+
+[package.extras]
+test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 name = "pandocfilters"
@@ -1523,6 +1633,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "uritemplate"
+version = "3.0.1"
+description = "URI templates"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "urllib3"
 version = "1.26.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1643,7 +1761,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "bc28d09808075ddbaf0b5026f0692c2200081ca0350089c402a0c8c1e3171863"
+content-hash = "120c0afc448da70b2f068a31ee7c8597e10acf9188c87120b0fbcab76ad7fbf8"
 
 [metadata.files]
 aiohttp = [
@@ -1808,6 +1926,10 @@ dagster = [
     {file = "dagster-0.11.6-py3-none-any.whl", hash = "sha256:852e33f9d614472e1d8f40995db3c23547eea4f4c66cd99f5e0797300478949f"},
     {file = "dagster-0.11.6.tar.gz", hash = "sha256:a4971b66b8fce7f083d707b5d239bda548c792688dc34f582c6708eb1cae0747"},
 ]
+dagster-gcp = [
+    {file = "dagster-gcp-0.11.8.tar.gz", hash = "sha256:6fdec8f54930a2188214bd147a428d4a455a70fd44184f760cf56fa0d481d271"},
+    {file = "dagster_gcp-0.11.8-py3-none-any.whl", hash = "sha256:e545d359b457929a517ec7ce64d7baaae2f6a2d4c632361e25875c5f97111416"},
+]
 dagster-graphql = [
     {file = "dagster-graphql-0.11.6.tar.gz", hash = "sha256:79b6f2ddcc90643bc5c2e8d0ec77edadded73975202c200ce1c5c4fdb2afb347"},
     {file = "dagster_graphql-0.11.6-py3-none-any.whl", hash = "sha256:69f7bf833408726adcb115acd35735e61e82267a0115e994a9e2ae7eddd54e11"},
@@ -1815,6 +1937,10 @@ dagster-graphql = [
 dagster-k8s = [
     {file = "dagster-k8s-0.11.6.tar.gz", hash = "sha256:a441e133c8d10f07a8c3a69cc83c19353ee60be9d7500c038e3b705f47d8f939"},
     {file = "dagster_k8s-0.11.6-py3-none-any.whl", hash = "sha256:c36e1b478c7d02bb3501f40c69296e79e4a468b834ada380e3c14770b9163eaa"},
+]
+dagster-pandas = [
+    {file = "dagster-pandas-0.11.8.tar.gz", hash = "sha256:cadd974e8f815f6718b9dc09b02ebae500fafa35544269e3f4d38f801f6e0e28"},
+    {file = "dagster_pandas-0.11.8-py3-none-any.whl", hash = "sha256:e8d74642654b1025f0faf5d6f8fb49234eb50c0a0344f5ebb060f83d72708bf9"},
 ]
 dagster-postgres = [
     {file = "dagster-postgres-0.11.6.tar.gz", hash = "sha256:3d063c667228a076eb68d835cfba3c5e931f9c93277190b2a2990409c2123895"},
@@ -1911,9 +2037,17 @@ google-api-core = [
     {file = "google-api-core-1.26.3.tar.gz", hash = "sha256:b914345c7ea23861162693a27703bab804a55504f7e6e9abcaff174d80df32ac"},
     {file = "google_api_core-1.26.3-py2.py3-none-any.whl", hash = "sha256:099762d4b4018cd536bcf85136bf337957da438807572db52f21dc61251be089"},
 ]
+google-api-python-client = [
+    {file = "google-api-python-client-1.12.8.tar.gz", hash = "sha256:f3b9684442eec2cfe9f9bb48e796ef919456b82142c7528c5fd527e5224f08bb"},
+    {file = "google_api_python_client-1.12.8-py2.py3-none-any.whl", hash = "sha256:3c4c4ca46b5c21196bec7ee93453443e477d82cbfa79234d1ce0645f81170eaf"},
+]
 google-auth = [
     {file = "google-auth-1.30.0.tar.gz", hash = "sha256:9ad25fba07f46a628ad4d0ca09f38dcb262830df2ac95b217f9b0129c9e42206"},
     {file = "google_auth-1.30.0-py2.py3-none-any.whl", hash = "sha256:588bdb03a41ecb4978472b847881e5518b5d9ec6153d3d679aa127a55e13b39f"},
+]
+google-auth-httplib2 = [
+    {file = "google-auth-httplib2-0.1.0.tar.gz", hash = "sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac"},
+    {file = "google_auth_httplib2-0.1.0-py2.py3-none-any.whl", hash = "sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10"},
 ]
 google-cloud-bigquery = [
     {file = "google-cloud-bigquery-2.16.0.tar.gz", hash = "sha256:69d3b82a2466de3f51d7ca63c1430e691ddccf7039dc6510e874d894548581f2"},
@@ -2084,6 +2218,10 @@ grpcio = [
 ]
 grpcio-health-checking = [
     {file = "grpcio-health-checking-1.37.0.tar.gz", hash = "sha256:fa0121870cac3a1689cc0659503a8bc692378398dec2a44f956284f271795b94"},
+]
+httplib2 = [
+    {file = "httplib2-0.19.1-py3-none-any.whl", hash = "sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4"},
+    {file = "httplib2-0.19.1.tar.gz", hash = "sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d"},
 ]
 humanfriendly = [
     {file = "humanfriendly-9.1-py2.py3-none-any.whl", hash = "sha256:d5c731705114b9ad673754f3317d9fa4c23212f36b29bdc4272a892eafc9bc72"},
@@ -2270,6 +2408,36 @@ nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
+numpy = [
+    {file = "numpy-1.20.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:70eb5808127284c4e5c9e836208e09d685a7978b6a216db85960b1a112eeace8"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6ca2b85a5997dabc38301a22ee43c82adcb53ff660b89ee88dded6b33687e1d8"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c5bf0e132acf7557fc9bb8ded8b53bbbbea8892f3c9a1738205878ca9434206a"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db250fd3e90117e0312b611574cd1b3f78bec046783195075cbd7ba9c3d73f16"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:637d827248f447e63585ca3f4a7d2dfaa882e094df6cfa177cc9cf9cd6cdf6d2"},
+    {file = "numpy-1.20.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8b7bb4b9280da3b2856cb1fc425932f46fba609819ee1c62256f61799e6a51d2"},
+    {file = "numpy-1.20.3-cp37-cp37m-win32.whl", hash = "sha256:67d44acb72c31a97a3d5d33d103ab06d8ac20770e1c5ad81bdb3f0c086a56cf6"},
+    {file = "numpy-1.20.3-cp37-cp37m-win_amd64.whl", hash = "sha256:43909c8bb289c382170e0282158a38cf306a8ad2ff6dfadc447e90f9961bef43"},
+    {file = "numpy-1.20.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f1452578d0516283c87608a5a5548b0cdde15b99650efdfd85182102ef7a7c17"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6e51534e78d14b4a009a062641f465cfaba4fdcb046c3ac0b1f61dd97c861b1b"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e515c9a93aebe27166ec9593411c58494fa98e5fcc219e47260d9ab8a1cc7f9f"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1c09247ccea742525bdb5f4b5ceeacb34f95731647fe55774aa36557dbb5fa4"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:66fbc6fed94a13b9801fb70b96ff30605ab0a123e775a5e7a26938b717c5d71a"},
+    {file = "numpy-1.20.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ea9cff01e75a956dbee133fa8e5b68f2f92175233de2f88de3a682dd94deda65"},
+    {file = "numpy-1.20.3-cp38-cp38-win32.whl", hash = "sha256:f39a995e47cb8649673cfa0579fbdd1cdd33ea497d1728a6cb194d6252268e48"},
+    {file = "numpy-1.20.3-cp38-cp38-win_amd64.whl", hash = "sha256:1676b0a292dd3c99e49305a16d7a9f42a4ab60ec522eac0d3dd20cdf362ac010"},
+    {file = "numpy-1.20.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:830b044f4e64a76ba71448fce6e604c0fc47a0e54d8f6467be23749ac2cbd2fb"},
+    {file = "numpy-1.20.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:55b745fca0a5ab738647d0e4db099bd0a23279c32b31a783ad2ccea729e632df"},
+    {file = "numpy-1.20.3-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d050e1e4bc9ddb8656d7b4f414557720ddcca23a5b88dd7cff65e847864c400"},
+    {file = "numpy-1.20.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9c65473ebc342715cb2d7926ff1e202c26376c0dcaaee85a1fd4b8d8c1d3b2f"},
+    {file = "numpy-1.20.3-cp39-cp39-win32.whl", hash = "sha256:16f221035e8bd19b9dc9a57159e38d2dd060b48e93e1d843c49cb370b0f415fd"},
+    {file = "numpy-1.20.3-cp39-cp39-win_amd64.whl", hash = "sha256:6690080810f77485667bfbff4f69d717c3be25e5b11bb2073e76bb3f578d99b4"},
+    {file = "numpy-1.20.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e465afc3b96dbc80cf4a5273e5e2b1e3451286361b4af70ce1adb2984d392f9"},
+    {file = "numpy-1.20.3.zip", hash = "sha256:e55185e51b18d788e49fe8305fd73ef4470596b33fc2c1ceb304566b99c71a69"},
+]
+oauth2client = [
+    {file = "oauth2client-4.1.3-py2.py3-none-any.whl", hash = "sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac"},
+    {file = "oauth2client-4.1.3.tar.gz", hash = "sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6"},
+]
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
     {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
@@ -2277,6 +2445,24 @@ oauthlib = [
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+]
+pandas = [
+    {file = "pandas-1.2.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c601c6fdebc729df4438ec1f62275d6136a0dd14d332fc0e8ce3f7d2aadb4dd6"},
+    {file = "pandas-1.2.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8d4c74177c26aadcfb4fd1de6c1c43c2bf822b3e0fc7a9b409eeaf84b3e92aaa"},
+    {file = "pandas-1.2.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:b730add5267f873b3383c18cac4df2527ac4f0f0eed1c6cf37fcb437e25cf558"},
+    {file = "pandas-1.2.4-cp37-cp37m-win32.whl", hash = "sha256:2cb7e8f4f152f27dc93f30b5c7a98f6c748601ea65da359af734dd0cf3fa733f"},
+    {file = "pandas-1.2.4-cp37-cp37m-win_amd64.whl", hash = "sha256:2111c25e69fa9365ba80bbf4f959400054b2771ac5d041ed19415a8b488dc70a"},
+    {file = "pandas-1.2.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:167693a80abc8eb28051fbd184c1b7afd13ce2c727a5af47b048f1ea3afefff4"},
+    {file = "pandas-1.2.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:612add929bf3ba9d27b436cc8853f5acc337242d6b584203f207e364bb46cb12"},
+    {file = "pandas-1.2.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:971e2a414fce20cc5331fe791153513d076814d30a60cd7348466943e6e909e4"},
+    {file = "pandas-1.2.4-cp38-cp38-win32.whl", hash = "sha256:68d7baa80c74aaacbed597265ca2308f017859123231542ff8a5266d489e1858"},
+    {file = "pandas-1.2.4-cp38-cp38-win_amd64.whl", hash = "sha256:bd659c11a4578af740782288cac141a322057a2e36920016e0fc7b25c5a4b686"},
+    {file = "pandas-1.2.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9db70ffa8b280bb4de83f9739d514cd0735825e79eef3a61d312420b9f16b758"},
+    {file = "pandas-1.2.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:298f0553fd3ba8e002c4070a723a59cdb28eda579f3e243bc2ee397773f5398b"},
+    {file = "pandas-1.2.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52d2472acbb8a56819a87aafdb8b5b6d2b3386e15c95bde56b281882529a7ded"},
+    {file = "pandas-1.2.4-cp39-cp39-win32.whl", hash = "sha256:d0877407359811f7b853b548a614aacd7dea83b0c0c84620a9a643f180060950"},
+    {file = "pandas-1.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:2b063d41803b6a19703b845609c0b700913593de067b552a8b24dd8eeb8c9895"},
+    {file = "pandas-1.2.4.tar.gz", hash = "sha256:649ecab692fade3cbfcf967ff936496b0cfba0af00a55dfaacd82bdda5cb2279"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.4.3.tar.gz", hash = "sha256:bc63fbb50534b4b1f8ebe1860889289e8af94a23bff7445259592df25a3906eb"},
@@ -2671,6 +2857,10 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
     {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
+uritemplate = [
+    {file = "uritemplate-3.0.1-py2.py3-none-any.whl", hash = "sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f"},
+    {file = "uritemplate-3.0.1.tar.gz", hash = "sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -19,6 +19,7 @@ python-dateutil = "^2.8.1"
 typing-extensions = "^3.7.4"
 pyyaml = "^5.3"
 broad-dagster-utils = "^0.2.0"
+dagster-gcp = "^0.11.8"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.5"


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1751)

## This PR

* Adds the `dagster-gcs` library and configs it to point at an env-specific bucket
* Configures an IO manager for all of our pipeline modes (besides test modes) to store intermediate outputs in said bucket
* Renames our Google Storage resource key to `"gcs"` for compatibility with the new IO manager