### PR TITLE
Set dataset region on creation

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -95,7 +95,9 @@ class DatasetManager:
                     "name": dataset_name,
                     "description": description,
                     "defaultProfileId": billing_profile_id,
-                    "schema": parsed_schema
+                    "schema": parsed_schema,
+                    "region": "US",
+                    "cloudPlatform": "gcp"
                 }
             )
             job_id: JobId = response.id


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1762)
We need to provide a region when creating a dataset to ensure it gets created in the `US` multi-region, not `us-central1`.
## This PR
* Threads in the necessary args

