### PR TITLE
Enable dev mode for validate egress

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/validate_egress.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/validate_egress.py
@@ -60,7 +60,7 @@ test_mode = ModeDefinition(
 
 
 @pipeline(
-    mode_defs=[prod_mode, local_mode, test_mode]
+    mode_defs=[prod_mode, local_mode, test_mode, dev_mode]
 )
 def validate_egress() -> None:
     notify_slack_of_egress_validation_results(post_import_validate())


### PR DESCRIPTION
## Why

This mode exists but is not enabled for the validate egress pipeline.

## This PR
* Adds the mode to the supported list

