### PR TITLE
Add real prod to the environments supported for dataset creation

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/common.py
+++ b/orchestration/dagster_orchestration/hca_manage/common.py
@@ -31,7 +31,8 @@ class ProblemCount:
 
 data_repo_host = {
     "dev": "https://jade.datarepo-dev.broadinstitute.org/",
-    "prod": "https://jade-terra.datarepo-prod.broadinstitute.org/"
+    "prod": "https://jade-terra.datarepo-prod.broadinstitute.org/",
+    "real_prod": "https://data.terra.bio/"
 }
 
 data_repo_profile_ids = {

--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -16,7 +16,8 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 def run(arguments: Optional[list[str]] = None) -> None:
     parser = DefaultHelpParser(description="A simple CLI to manage TDR datasets.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)
-    parser.add_argument("-e", "--env", help="The Jade environment to target", choices=["dev", "prod"], required=True)
+    parser.add_argument("-e", "--env", help="The Jade environment to target",
+                        choices=["dev", "prod", "real_prod"], required=True)
 
     dataset_flags = parser.add_mutually_exclusive_group(required=True)
     dataset_flags.add_argument("-c", "--create", help="Flag to create a dataset", action="store_true")
@@ -35,7 +36,6 @@ def run(arguments: Optional[list[str]] = None) -> None:
 
     args = parser.parse_args(arguments)
     host = data_repo_host[args.env]
-
     if args.remove:
         if query_yes_no("Are you sure?"):
             remove_dataset(args, host)
@@ -128,3 +128,7 @@ class DatasetManager:
 
     def enumerate_dataset(self, dataset_name: str) -> str:
         return f"{self.data_repo_client.enumerate_datasets(filter=dataset_name)}"
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1775)
We want to setup the prod lungmap dataset in "real" prod.

## This PR
* Adds `real_prod` to the set of supported environments for dataset creation

