### PR TITLE
Add dataset policy members on creation

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/common.py
+++ b/orchestration/dagster_orchestration/hca_manage/common.py
@@ -8,13 +8,8 @@ from dagster import make_python_type_usable_as_dagster_type
 from dagster.core.types.dagster_type import String as DagsterString
 
 from dagster_utils.contrib.google import default_google_access_token
+from dagster_utils.contrib.data_repo.typing import JobId
 from data_repo_client import ApiClient, Configuration, RepositoryApi
-
-
-# alias for str to make the return type for jade API calls a little clearer
-class JobId(str):
-    pass
-
 
 make_python_type_usable_as_dagster_type(JobId, DagsterString)
 

--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import json
 import logging
 import sys
-from typing import Optional
+from typing import Optional, Callable, Any
 
 from data_repo_client import RepositoryApi, ApiException
 from dagster_utils.contrib.data_repo.typing import JobId
@@ -13,11 +13,8 @@ from hca_manage import __version__ as hca_manage_version
 from hca_manage.common import data_repo_host, DefaultHelpParser, get_api_client, query_yes_no
 
 MAX_DATASET_CREATE_POLL_SECONDS = 120
-DATASET_CREATE_POLL_INTERVAL_SECONDS = 120
-RUNNER_MEMBERS = {
-    "hca-dagster-runner@broad-dsp-monster-hca-dev.iam.gserviceaccount.com",
-    "hca-argo-runner@broad-dsp-monster-hca-dev.iam.gserviceaccount.com"
-}
+DATASET_CREATE_POLL_INTERVAL_SECONDS = 2
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 
@@ -36,6 +33,9 @@ def run(arguments: Optional[list[str]] = None) -> None:
     dataset_create_args = parser.add_argument_group()
     dataset_create_args.add_argument("-b", "--billing_profile_id", help="Billing profile ID")
     dataset_create_args.add_argument("-j", "--schema_path", help="Path to table schema (JSON)")
+    dataset_create_args.add_argument(
+        "-p", "--policy-members", help="CSV list of emails to grant steward access to this dataset"
+    )
 
     # delete
     dataset_delete_args = parser.add_mutually_exclusive_group(required=True)
@@ -56,9 +56,9 @@ def run(arguments: Optional[list[str]] = None) -> None:
         _exec_tdr_operation(_query_dataset, args, host)
 
 
-def _exec_tdr_operation(op, *args, **kwargs):
+def _exec_tdr_operation(op: Callable[..., None], *args: Any) -> None:
     try:
-        op(*args, **kwargs)
+        op(*args)
     except ApiException as e:
         if e.status == 401:
             logging.error(f"Permission denied, check your gcloud credentials")
@@ -71,40 +71,23 @@ def _remove_dataset(args: argparse.Namespace, host: str) -> None:
 
 
 def _create_dataset(args: argparse.Namespace, host: str) -> None:
+    policy_members = set(args.policy_members.split(','))
     client = get_api_client(host=host)
+    with open(args.schema_path, "r") as f:
+        # verify that the schema is valid json
+        parsed_schema = json.load(f)
+
     hca = DatasetManager(environment=args.env, data_repo_client=client)
-    job_id = hca.create_dataset(
-        dataset_name=args.dataset_name,
-        billing_profile_id=args.billing_profile_id,
-        schema_path=args.schema_path
+    hca.create_dataset_with_policy_members(
+        args.dataset_name,
+        args.billing_profile_id,
+        policy_members,
+        parsed_schema
     )
-
-    try:
-        poll_job(
-            job_id,
-            MAX_DATASET_CREATE_POLL_SECONDS,
-            DATASET_CREATE_POLL_INTERVAL_SECONDS,
-            client
-        )
-    except JobPollException:
-        job_result = client.retrieve_job_result(job_id)
-        logging.error("Create job failed, results =")
-        logging.error(job_result)
-        sys.exit(1)
-
-    job_result = client.retrieve_job_result(job_id)
-    dataset_id = job_result["dataset_id"]
-
-    for runner_email in RUNNER_MEMBERS:
-        client.add_dataset_policy_member(dataset_id, policy_name="steward", policy_member={
-            "email": runner_email
-        })
 
 
 def _query_dataset(args: argparse.Namespace, host: str) -> None:
     hca = DatasetManager(environment=args.env, data_repo_client=get_api_client(host=host))
-    import pdb
-    pdb.set_trace()
     logging.info(hca.enumerate_dataset(dataset_name=args.dataset_name))
 
 
@@ -113,36 +96,66 @@ class DatasetManager:
     environment: str
     data_repo_client: RepositoryApi
 
+    def create_dataset_with_policy_members(
+            self,
+            dataset_name: str,
+            billing_profile_id: str,
+            policy_members: set[str],
+            schema: dict[str, Any]
+    ) -> None:
+        job_id = self.create_dataset(
+            dataset_name=dataset_name,
+            billing_profile_id=billing_profile_id,
+            schema=schema
+        )
+
+        try:
+            poll_job(
+                job_id,
+                MAX_DATASET_CREATE_POLL_SECONDS,
+                DATASET_CREATE_POLL_INTERVAL_SECONDS,
+                self.data_repo_client
+            )
+        except JobPollException:
+            job_result = self.data_repo_client.retrieve_job_result(job_id)
+            logging.error("Create job failed, results =")
+            logging.error(job_result)
+            sys.exit(1)
+
+        job_result = self.data_repo_client.retrieve_job_result(job_id)
+        dataset_id = job_result["id"]
+        logging.info(f"Dataset created, id = {dataset_id}")
+        logging.info(f"Adding policy_members {policy_members}")
+        self.add_policy_members(dataset_id, policy_members, "steward")
+
     def create_dataset(
             self,
             dataset_name: str,
             billing_profile_id: str,
-            schema_path: str,
+            schema: dict[str, Any],
             description: Optional[str] = None) -> JobId:
         """
         Creates a dataset in the data repo.
         :param dataset_name:  Name of the dataset
         :param billing_profile_id: GCP billing profile ID
-        :param schema_path: Local path to a file containing a schema for the dataset
+        :param schema: Dict containing the dataset's schema
         :param description: Optional description for the dataset
         :return: Job ID of the dataset creation job
         """
-        with open(schema_path, "r") as f:
-            # verify that the schema is valid json
-            parsed_schema = json.load(f)
-            response = self.data_repo_client.create_dataset(
-                dataset={
-                    "name": dataset_name,
-                    "description": description,
-                    "defaultProfileId": billing_profile_id,
-                    "schema": parsed_schema,
-                    "region": "US",
-                    "cloudPlatform": "gcp"
-                }
-            )
-            job_id: JobId = response.id
-            logging.info(f"Dataset creation job id: {job_id}")
-            return job_id
+
+        response = self.data_repo_client.create_dataset(
+            dataset={
+                "name": dataset_name,
+                "description": description,
+                "defaultProfileId": billing_profile_id,
+                "schema": schema,
+                "region": "US",
+                "cloudPlatform": "gcp"
+            }
+        )
+        job_id: JobId = response.id
+        logging.info(f"Dataset creation job id: {job_id}")
+        return job_id
 
     def delete_dataset(self, dataset_name: Optional[str] = None, dataset_id: Optional[str] = None) -> JobId:
         """
@@ -167,7 +180,28 @@ class DatasetManager:
         return delete_response_id
 
     def enumerate_dataset(self, dataset_name: str) -> str:
+        """
+        Enumerates TDR datasets, filtering on the given dataset_name
+        """
         return f"{self.data_repo_client.enumerate_datasets(filter=dataset_name)}"
+
+    def add_policy_members(
+        self,
+        dataset_id: str,
+        policy_members: set[str],
+        policy_name: str
+    ) -> None:
+        """
+        Adds the supplied policy members (emails) to the given policy name
+        """
+        for member in policy_members:
+            self.data_repo_client.add_dataset_policy_member(
+                dataset_id,
+                policy_name=policy_name,
+                policy_member={
+                    "email": member
+                }
+            )
 
 
 if __name__ == '__main__':

--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -5,9 +5,10 @@ import logging
 from typing import Optional
 
 from data_repo_client import RepositoryApi, SnapshotRequestModel, SnapshotRequestContentsModel
+from dagster_utils.contrib.data_repo.typing import JobId
 
 from hca_manage import __version__ as hca_manage_version
-from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelpParser, JobId, get_api_client,\
+from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelpParser, get_api_client,\
     query_yes_no
 
 

--- a/orchestration/dagster_orchestration/hca_manage/soft_delete.py
+++ b/orchestration/dagster_orchestration/hca_manage/soft_delete.py
@@ -9,8 +9,9 @@ from data_repo_client import RepositoryApi, DataDeletionRequest
 import google.auth.credentials
 from google.cloud import storage
 
+from dagster_utils.contrib.data_repo.typing import JobId
 from hca_manage import __version__ as hca_manage_version
-from hca_manage.common import data_repo_host, DefaultHelpParser, JobId, get_api_client, get_dataset_id, query_yes_no
+from hca_manage.common import data_repo_host, DefaultHelpParser, get_api_client, get_dataset_id, query_yes_no
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_check_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_check_manager.py
@@ -14,7 +14,7 @@ class CheckManagerTestCase(unittest.TestCase):
     def setUp(self):
         self.manager = CheckManager(
             environment='dev',
-            data_repo_client=MagicMock(autospec=RepositoryApi),
+            data_repo_client=MagicMock(spec=RepositoryApi),
             project='project-id',
             dataset='datasetname',
         )

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -10,7 +10,7 @@ class DatasetManagerTestCase(unittest.TestCase):
     def setUp(self):
         self.manager = DatasetManager(
             'dev',
-            MagicMock(autospec=RepositoryApi)
+            MagicMock(spec=RepositoryApi, instance=True)
         )
 
     def test_delete_dataset_fetches_id_if_missing(self):
@@ -35,3 +35,17 @@ class DatasetManagerTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.manager.delete_dataset()
+
+    def test_create_dataset_with_policy(self):
+        self.manager.data_repo_client.create_dataset = Mock()
+        self.manager.data_repo_client.retrieve_job_result = Mock(return_value={"id": "fake_dataset_id"})
+
+        self.manager.create_dataset_with_policy_members(
+            "example",
+            "fake_billing_id",
+            {"abc@example.com", "def@example.com"},
+            {"fake": "schema"}
+        )
+
+        self.manager.data_repo_client.create_dataset.assert_called_once()
+        self.assertEqual(self.manager.data_repo_client.add_dataset_policy_member.call_count, 2)

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_snapshot_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_snapshot_manager.py
@@ -11,7 +11,7 @@ class SnapshotManagerTestCase(unittest.TestCase):
     def setUp(self):
         self.manager = SnapshotManager(
             environment='dev',
-            data_repo_client=MagicMock(autospec=RepositoryApi),
+            data_repo_client=MagicMock(spec=RepositoryApi),
             dataset='datasetname',
         )
 

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_soft_delete_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_soft_delete_manager.py
@@ -15,7 +15,7 @@ class SoftDeleteManagerTestCase(unittest.TestCase):
     def setUp(self):
         self.manager = SoftDeleteManager(
             environment='dev',
-            data_repo_client=MagicMock(autospec=RepositoryApi),
+            data_repo_client=MagicMock(spec=RepositoryApi),
             project='project-id',
             dataset='datasetname',
         )

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/data_repo.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/data_repo.py
@@ -1,7 +1,6 @@
-import time
-
 from dagster import configured, EventMetadataEntry, Failure, Int, solid
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
+from dagster_utils.contrib.data_repo import jobs
 from dagster_utils.typing import DagsterConfigDict
 
 from hca_manage.common import JobId
@@ -15,26 +14,19 @@ from hca_manage.common import JobId
     }
 )
 def base_wait_for_job_completion(context: AbstractComputeExecutionContext, job_id: JobId) -> JobId:
-    time_waited = 0
+    max_wait_time_seconds = context.solid_config['max_wait_time_seconds']
+    poll_interval_seconds = context.solid_config['poll_interval_seconds']
+    client = context.resources.data_repo_client
 
-    max_wait_time = context.solid_config['max_wait_time_seconds']
-
-    while time_waited < max_wait_time:
-        job_info = context.resources.data_repo_client.retrieve_job(job_id)
-        if job_info.completed:
-            if job_info.job_status == "failed":
-                raise Failure(
-                    description="Job did not complete successfully.",
-                    metadata_entries=[
-                        EventMetadataEntry.text(job_id, "job_id", description="Failing data repo job ID")
-                    ]
-                )
-            return job_id
-
-        time.sleep(context.solid_config['poll_interval_seconds'])
-        time_waited += context.solid_config['poll_interval_seconds']
-
-    raise Failure(f"Exceeded max wait time of {max_wait_time} polling for status of job {job_id}.")
+    try:
+        return jobs.poll_job(job_id, max_wait_time_seconds, poll_interval_seconds, client)
+    except jobs.JobPollException as e:
+        raise Failure(
+            description=e.message,
+            metadata_entries=[
+                EventMetadataEntry.text(job_id, "job_id", description="Failing data repo job ID")
+            ]
+        )
 
 
 @configured(base_wait_for_job_completion)

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/load_table.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/load_table.py
@@ -1,10 +1,10 @@
 from dagster import composite_solid, solid, Nothing
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
-from data_repo_client import RepositoryApi, JobModel
-from google.cloud.bigquery import Client, DestinationFormat
+from google.cloud.bigquery import DestinationFormat
 from google.cloud.bigquery.client import RowIterator
 
-from hca_manage.common import JobId
+from dagster_utils.contrib.data_repo.typing import JobId
+from data_repo_client import RepositoryApi, JobModel
 from hca_orchestration.contrib.bigquery import BigQueryService
 from hca_orchestration.resources.config.hca_dataset import TargetHcaDataset
 from hca_orchestration.resources.config.scratch import ScratchConfig

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/poll_ingest_job.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/poll_ingest_job.py
@@ -20,10 +20,11 @@ def base_check_data_ingest_job_result(context: AbstractComputeExecutionContext, 
     # we need to poll on the endpoint as a workaround for a race condition in TDR (DR-1791)
     def __fetch_job_results(jid: JobId) -> Optional[JobModel]:
         try:
-            context.log.info(f"polling on job_id = {jid}")
+            context.log.info(f"Fetching job results for job_id = {jid}")
             return context.resources.data_repo_client.retrieve_job_result(jid)
         except ApiException as ae:
             if 500 <= ae.status <= 599:
+                context.log.info(f"Data repo returned error when fetching results for job_id = {jid}, scheduling retry")
                 return None
             raise
 

--- a/orchestration/dagster_orchestration/poetry.lock
+++ b/orchestration/dagster_orchestration/poetry.lock
@@ -19,7 +19,7 @@ speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
 name = "alembic"
-version = "1.6.2"
+version = "1.6.3"
 description = "A database migration tool for SQLAlchemy."
 category = "main"
 optional = false
@@ -112,20 +112,25 @@ webencodings = "*"
 
 [[package]]
 name = "broad-dagster-utils"
-version = "0.4.0"
+version = "0.3.2"
 description = "Common utilities and objects for building Dagster pipelines"
 category = "main"
 optional = false
-python-versions = ">=3.9,<3.10"
+python-versions = "~3.9"
+develop = true
 
 [package.dependencies]
-argo-workflows = ">=5.0.0,<6.0.0"
-dagster = ">=0.11.6,<0.12.0"
-data-repo-client = ">=1.64.0,<2.0.0"
-google-cloud-bigquery = ">=2.15.0,<3.0.0"
-google-cloud-storage = ">=1.38.0,<2.0.0"
-PyYAML = ">=5.4.1,<6.0.0"
-slackclient = ">=2.9.3,<3.0.0"
+argo-workflows = "^5.0.0"
+dagster = "^0.11.6"
+data-repo-client = "^1.64.0"
+google-cloud-bigquery = "^2.15.0"
+google-cloud-storage = "^1.38.0"
+PyYAML = "^5.4.1"
+slackclient = "^2.9.3"
+
+[package.source]
+type = "directory"
+url = "../../../dagster-utils"
 
 [[package]]
 name = "cached-property"
@@ -613,7 +618,7 @@ six = "*"
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "2.16.1"
+version = "2.17.0"
 description = "Google BigQuery API client library"
 category = "main"
 optional = false
@@ -864,7 +869,7 @@ pyreadline = {version = "*", markers = "sys_platform == \"win32\""}
 
 [[package]]
 name = "identify"
-version = "2.2.4"
+version = "2.2.5"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -1208,7 +1213,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "pre-commit"
-version = "2.12.1"
+version = "2.13.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -1712,7 +1717,7 @@ python-versions = "*"
 
 [[package]]
 name = "websocket-client"
-version = "1.0.0"
+version = "1.0.1"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
@@ -1778,7 +1783,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "0e6b55673e4f3d17c9ba88160086edfe368c21088d8841ea906876907151ebad"
+content-hash = "0604f81b687cf4624238a7f06fd547342e2cbebdf78a18d9393c0ee94bd2031f"
 
 [metadata.files]
 aiohttp = [
@@ -1821,7 +1826,8 @@ aiohttp = [
     {file = "aiohttp-3.7.4.post0.tar.gz", hash = "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf"},
 ]
 alembic = [
-    {file = "alembic-1.6.2.tar.gz", hash = "sha256:fb9a39a7c68e55490be962fb5f70463d384d340e6563d6e3911447778e3b4576"},
+    {file = "alembic-1.6.3-py2.py3-none-any.whl", hash = "sha256:5a01e9ac338e7380aea1d8a038fcc927cf309cc0b90ede4472c601282054f1b3"},
+    {file = "alembic-1.6.3.tar.gz", hash = "sha256:6d243986586709e9358accdd5ba35d16dd7ca5572681f0d683638ced407504c8"},
 ]
 aniso8601 = [
     {file = "aniso8601-7.0.0-py2.py3-none-any.whl", hash = "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"},
@@ -1855,10 +1861,7 @@ bleach = [
     {file = "bleach-3.3.0-py2.py3-none-any.whl", hash = "sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125"},
     {file = "bleach-3.3.0.tar.gz", hash = "sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433"},
 ]
-broad-dagster-utils = [
-    {file = "broad_dagster_utils-0.4.0-py3-none-any.whl", hash = "sha256:f6213657435d635c4d9330b8d1b289d11521d88756848591ff5a98828908f7b3"},
-    {file = "broad_dagster_utils-0.4.0.tar.gz", hash = "sha256:28d171c9ade3bceb918dc70d84e6b0c4b118de5bd053f5eaaa3bf4733ebec68a"},
-]
+broad-dagster-utils = []
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
     {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
@@ -2066,8 +2069,8 @@ google-auth-httplib2 = [
     {file = "google_auth_httplib2-0.1.0-py2.py3-none-any.whl", hash = "sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10"},
 ]
 google-cloud-bigquery = [
-    {file = "google-cloud-bigquery-2.16.1.tar.gz", hash = "sha256:69ce0d64cf06e4163072898ed50623af30c4601fb11f972cbde85c355bb45a89"},
-    {file = "google_cloud_bigquery-2.16.1-py2.py3-none-any.whl", hash = "sha256:cb88d27522d88a2fb41e9f330d8f835c4abd9c341815fe1bf8fe4bb82d3436dd"},
+    {file = "google-cloud-bigquery-2.17.0.tar.gz", hash = "sha256:88ed16b2a5761ad2eebd4a6e23f7f022630291c92410c123b04f77bbda9ad469"},
+    {file = "google_cloud_bigquery-2.17.0-py2.py3-none-any.whl", hash = "sha256:922d8ed28262793b6a9d23e10ffc785963f3e574686c77a3ed57c93acdc42200"},
 ]
 google-cloud-core = [
     {file = "google-cloud-core-1.6.0.tar.gz", hash = "sha256:c6abb18527545379fc82efc4de75ce9a3772ccad2fc645adace593ba097cbb02"},
@@ -2257,8 +2260,8 @@ humanfriendly = [
     {file = "humanfriendly-9.1.tar.gz", hash = "sha256:066562956639ab21ff2676d1fda0b5987e985c534fc76700a19bd54bcb81121d"},
 ]
 identify = [
-    {file = "identify-2.2.4-py2.py3-none-any.whl", hash = "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"},
-    {file = "identify-2.2.4.tar.gz", hash = "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e"},
+    {file = "identify-2.2.5-py2.py3-none-any.whl", hash = "sha256:9c3ab58543c03bd794a1735e4552ef6dec49ec32053278130d525f0982447d47"},
+    {file = "identify-2.2.5.tar.gz", hash = "sha256:bc1705694253763a3160b943316867792ec00ba7a0ee40b46e20aebaf4e0c46a"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -2509,8 +2512,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.12.1-py2.py3-none-any.whl", hash = "sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712"},
-    {file = "pre_commit-2.12.1.tar.gz", hash = "sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9"},
+    {file = "pre_commit-2.13.0-py2.py3-none-any.whl", hash = "sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4"},
+    {file = "pre_commit-2.13.0.tar.gz", hash = "sha256:764972c60693dc668ba8e86eb29654ec3144501310f7198742a767bec385a378"},
 ]
 promise = [
     {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
@@ -2904,8 +2907,8 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 websocket-client = [
-    {file = "websocket-client-1.0.0.tar.gz", hash = "sha256:5051b38a2f4c27fbd7ca077ebb23ec6965a626ded5a95637f36be1b35b6c4f81"},
-    {file = "websocket_client-1.0.0-py2.py3-none-any.whl", hash = "sha256:57f876f1af4731cacb806cf54d02f5fbf75dee796053b9a5b94fd7c1d9621db9"},
+    {file = "websocket-client-1.0.1.tar.gz", hash = "sha256:3e2bf58191d4619b161389a95bdce84ce9e0b24eb8107e7e590db682c2d0ca81"},
+    {file = "websocket_client-1.0.1-py2.py3-none-any.whl", hash = "sha256:abf306dc6351dcef07f4d40453037e51cc5d9da2ef60d0fc5d0fe3bcda255372"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/orchestration/dagster_orchestration/poetry.lock
+++ b/orchestration/dagster_orchestration/poetry.lock
@@ -112,25 +112,20 @@ webencodings = "*"
 
 [[package]]
 name = "broad-dagster-utils"
-version = "0.3.2"
+version = "0.4.1"
 description = "Common utilities and objects for building Dagster pipelines"
 category = "main"
 optional = false
-python-versions = "~3.9"
-develop = true
+python-versions = ">=3.9,<3.10"
 
 [package.dependencies]
-argo-workflows = "^5.0.0"
-dagster = "^0.11.6"
-data-repo-client = "^1.64.0"
-google-cloud-bigquery = "^2.15.0"
-google-cloud-storage = "^1.38.0"
-PyYAML = "^5.4.1"
-slackclient = "^2.9.3"
-
-[package.source]
-type = "directory"
-url = "../../../dagster-utils"
+argo-workflows = ">=5.0.0,<6.0.0"
+dagster = ">=0.11.6,<0.12.0"
+data-repo-client = ">=1.64.0,<2.0.0"
+google-cloud-bigquery = ">=2.15.0,<3.0.0"
+google-cloud-storage = ">=1.38.0,<2.0.0"
+PyYAML = ">=5.4.1,<6.0.0"
+slackclient = ">=2.9.3,<3.0.0"
 
 [[package]]
 name = "cached-property"
@@ -1257,7 +1252,7 @@ testing = ["google-api-core[grpc] (>=1.22.2)"]
 
 [[package]]
 name = "protobuf"
-version = "3.17.0"
+version = "3.17.1"
 description = "Protocol Buffers"
 category = "main"
 optional = false
@@ -1680,7 +1675,7 @@ brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.4.6"
+version = "20.4.7"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -1783,7 +1778,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "0604f81b687cf4624238a7f06fd547342e2cbebdf78a18d9393c0ee94bd2031f"
+content-hash = "a9d483a8891323a7c6cbc435ae50e4281bc0cb23be9bdd586bcc90c6da773179"
 
 [metadata.files]
 aiohttp = [
@@ -1861,7 +1856,10 @@ bleach = [
     {file = "bleach-3.3.0-py2.py3-none-any.whl", hash = "sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125"},
     {file = "bleach-3.3.0.tar.gz", hash = "sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433"},
 ]
-broad-dagster-utils = []
+broad-dagster-utils = [
+    {file = "broad_dagster_utils-0.4.1-py3-none-any.whl", hash = "sha256:87d969014bdef269ec826482a9c050167825c9a9b1fb931db91976d557cb6c21"},
+    {file = "broad_dagster_utils-0.4.1.tar.gz", hash = "sha256:fe08f5a113302021289003aac15bb80f8fc14bdd00bc8da321c4b9ba32b1386f"},
+]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
     {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
@@ -2523,29 +2521,29 @@ proto-plus = [
     {file = "proto_plus-1.18.1-py3-none-any.whl", hash = "sha256:600e2793ec1a0bf2b9e5ba18cd9eccbc1bc690a03c73b571bbe59789fbaaeecc"},
 ]
 protobuf = [
-    {file = "protobuf-3.17.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:15351df904347da2081a2eebc42b192c29724eb57dbe56dae440be843f1e4779"},
-    {file = "protobuf-3.17.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5356981c1919782b8c2e3ea5c5d85ad5937b8178a025ac9edc2f2ca5b4a717ae"},
-    {file = "protobuf-3.17.0-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:eac0a2a7ea99e17175f6e7b53cdc9004ed786c072fbdf933def0e454e14fd323"},
-    {file = "protobuf-3.17.0-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4c8d0997fdc0a4cf9de7950d598ce6974b22e8618bbcf1d15e9842010cf8420a"},
-    {file = "protobuf-3.17.0-cp35-cp35m-win32.whl", hash = "sha256:9ae321459d4890c3939c536382f75e232c9e91ce506310353c8a15ad5c379e0d"},
-    {file = "protobuf-3.17.0-cp35-cp35m-win_amd64.whl", hash = "sha256:295944ef0772498d7bf75f6aa5d4dfcfd02f5ce70f735b406e52e43ac3914d38"},
-    {file = "protobuf-3.17.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:850f429bd2399525d339d05bc809f090f16d3d88737bed637d355a5ee8d3b81a"},
-    {file = "protobuf-3.17.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:809a96d5a1a74538728710f9104f43ae77f5e48bde274ee321b10a324ba52e4f"},
-    {file = "protobuf-3.17.0-cp36-cp36m-win32.whl", hash = "sha256:8a3ac375539055164f31a330770f137875307e6f04c21e2647f2e7139c501295"},
-    {file = "protobuf-3.17.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3d338910b10b88b18581cf6877b3938b2e262e8fdc2c1057f5a291787de63183"},
-    {file = "protobuf-3.17.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1488f786bd1912f97796cf5def8cacf433735616896cf7ed9dc786cee693dfc8"},
-    {file = "protobuf-3.17.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:bcaff977db178f0bfde10bab0d23a5f5adf5964adba70c315e45922a1c55eb90"},
-    {file = "protobuf-3.17.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:939ce06846ddfec99c0bff510510b3ee45778e7a3aec6544d1f36526e5fecb67"},
-    {file = "protobuf-3.17.0-cp37-cp37m-win32.whl", hash = "sha256:3237acce5b666c7b0f45785cc2d0809796d4df3593bd68338aebf25408139188"},
-    {file = "protobuf-3.17.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2f77afe33bb86c7d34221a86193256d69aa10818620fe4a7513d98211d67d672"},
-    {file = "protobuf-3.17.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:acc9f2091ace3de429eee424ab7ba0bc52a6aa9ffc9909e5c4de259a3f71db46"},
-    {file = "protobuf-3.17.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a29631f4f8bcf79b12a59e83d238d888de5034871461d788c74c68218ad75049"},
-    {file = "protobuf-3.17.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:05c304396e309661c45e3a97bd2d8da1fc2bab743ed2ca880bcb757271c40c0e"},
-    {file = "protobuf-3.17.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:baea44967071e6a51e705e4e88aebf35f530a14004cc69f60a185e5d7e13de7e"},
-    {file = "protobuf-3.17.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3b5c461af5a3cebd796c73370db929b7e24cbaba655eefdc044226bc8a843d6b"},
-    {file = "protobuf-3.17.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:44399393c3a8cc04a4cfbdc721dd7f2114497efda582e946a91b8c4290ae5ff5"},
-    {file = "protobuf-3.17.0-py2.py3-none-any.whl", hash = "sha256:e32ef0c9f4b548c80d94dfff8b4130ca2ff3d50caaf2455889e3f5b8a01e8038"},
-    {file = "protobuf-3.17.0.tar.gz", hash = "sha256:05dfe9319939a8473c21b469f34f6486646e54fb8542637cf7ed8e2fbfe21538"},
+    {file = "protobuf-3.17.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6e48c9b26d8e262331c79b208c4bf6b499a71912b1213d77b63c5ca248fc2a4e"},
+    {file = "protobuf-3.17.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d06ef0f7873e04e2d1a2bfa0701d063e4dde5242b2946c6f071a442e4cb3be0b"},
+    {file = "protobuf-3.17.1-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:437d4681160ac5310457c4dc8ab973ec56769a236c479393c53fa71a26dfb38f"},
+    {file = "protobuf-3.17.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4ef4865ee740d5b45adfc96481adf1fcbfbb454bd51b86f4c4a5065262d0b08b"},
+    {file = "protobuf-3.17.1-cp35-cp35m-win32.whl", hash = "sha256:5057744a363d65d2780dc01fa751bb14e860c507b2598b22af241aabb28a0ae9"},
+    {file = "protobuf-3.17.1-cp35-cp35m-win_amd64.whl", hash = "sha256:94be4d5c2ba372ff159b2cc804d274acbaa7ebf361966f5619f99880c7c09a3c"},
+    {file = "protobuf-3.17.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fea786428b34385b073ef619d896282889b432b87dc043c0b815c72d35d64025"},
+    {file = "protobuf-3.17.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2c6ad26f079301bcf9f1b5d5b4b2dbac0e2e7c0111c6fbecf94f558952c78ee0"},
+    {file = "protobuf-3.17.1-cp36-cp36m-win32.whl", hash = "sha256:ad17d3dd80f3377fc70a9dd677ec51231a892f9f65783cf7d2d24ee381f0feca"},
+    {file = "protobuf-3.17.1-cp36-cp36m-win_amd64.whl", hash = "sha256:0f237c1e84e46747397a3e8173edb3116e81163b2878fc944a5193b05876eaee"},
+    {file = "protobuf-3.17.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c1631570af7aae611f1cd7c6918fe4a7154507169ef30e8c5f380eba36ee2659"},
+    {file = "protobuf-3.17.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:8a509097ba25452c9b44198843b0df67f921bd36f37adcbcfaaf6ee5cbe09132"},
+    {file = "protobuf-3.17.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cbd132f0aa7180f099d3c47fecfbcdca1590ef3b7da8346146192ba580c9b24e"},
+    {file = "protobuf-3.17.1-cp37-cp37m-win32.whl", hash = "sha256:762faa8873d0569466cf66128bdbadd5e500600bdf2f87cf039493ed9d2725b6"},
+    {file = "protobuf-3.17.1-cp37-cp37m-win_amd64.whl", hash = "sha256:27c7c933b838a0837eb1f429e7994310ee8577a7b69abc38e84d5db97a2650a2"},
+    {file = "protobuf-3.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fcace96670b8512e805d6e275bd59b860967a7648e05cfad35ec1e7c03d7262"},
+    {file = "protobuf-3.17.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2a88be54fce118d69f083b847554afd1852053c0869bdac396678ec9ec6a94d5"},
+    {file = "protobuf-3.17.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ad8cdbc594c886483970ac274b5af98483b272e873b7c5dac60aa3a7222301b3"},
+    {file = "protobuf-3.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b92f95994ff27a6992ea2cf3f369476ad0065986eb00252b760d0bc55c5454a8"},
+    {file = "protobuf-3.17.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:40bf764b63f06a816b1c079f7718184fdd8dbfd9dad3cd1a446382492ca00b3e"},
+    {file = "protobuf-3.17.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a15898d88307dba0363767b30960396a2dec74b8ffe7bcb4e885312a569eda3f"},
+    {file = "protobuf-3.17.1-py2.py3-none-any.whl", hash = "sha256:36d306dda3c159a5fe0025ba0e9728aac00dd69523dd12ee3fb7b1717cd80e7d"},
+    {file = "protobuf-3.17.1.tar.gz", hash = "sha256:25bc4f1c23aced9b3a9e70eef7f03e63bcbd6cfbd881a91b5688412dce8992e1"},
 ]
 psutil = [
     {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
@@ -2880,8 +2878,8 @@ urllib3 = [
     {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.4.6-py2.py3-none-any.whl", hash = "sha256:307a555cf21e1550885c82120eccaf5acedf42978fd362d32ba8410f9593f543"},
-    {file = "virtualenv-20.4.6.tar.gz", hash = "sha256:72cf267afc04bf9c86ec932329b7e94db6a0331ae9847576daaa7ca3c86b29a4"},
+    {file = "virtualenv-20.4.7-py2.py3-none-any.whl", hash = "sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76"},
+    {file = "virtualenv-20.4.7.tar.gz", hash = "sha256:14fdf849f80dbb29a4eb6caa9875d476ee2a5cf76a5f5415fa2f1606010ab467"},
 ]
 watchdog = [
     {file = "watchdog-2.1.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:581e3548159fe7d2a9f377a1fbcb41bdcee46849cca8ab803c7ac2e5e04ec77c"},

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -18,8 +18,9 @@ google-cloud-storage = "^1.3.5"
 python-dateutil = "^2.8.1"
 typing-extensions = "^3.7.4"
 pyyaml = "^5.3"
-broad-dagster-utils = "^0.4.0"
 dagster-gcp = "^0.11.10"
+broad-dagster-utils = {path = "../../../dagster-utils", develop = true}
+
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.5"

--- a/orchestration/dagster_orchestration/pyproject.toml
+++ b/orchestration/dagster_orchestration/pyproject.toml
@@ -19,7 +19,7 @@ python-dateutil = "^2.8.1"
 typing-extensions = "^3.7.4"
 pyyaml = "^5.3"
 dagster-gcp = "^0.11.10"
-broad-dagster-utils = {path = "../../../dagster-utils", develop = true}
+broad-dagster-utils = "0.4.1"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1717)
We want to add relevant dataset policy members at the time of creation to avoid manual setup in swagger.

## This PR
* Adds a `create_dataset_with_policy_members` method to the `hca_manage` class, which creates the dataset, polls on it's creation then adds the specified policy members, along with a test
* Reflects the extracted job polling code from [this dagster-utils ](https://github.com/broadinstitute/dagster-utils/pull/15)PR
* Adds an `_exec_tdr_op` helper method to the dataset manager, which wraps all TDR calls in the dataset script with a handler that looks for 401 responses. If a 401 is received, it outputs a more helpful message rather than the usual traceback spew. 


## TODO
- [x] Update `dagster-utils` version once related PR is merged

