### PR TITLE
Autogenerate HCA schema when creating dataset

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -76,8 +76,8 @@ test_mode = ModeDefinition(
 )
 def snapshot_start_notification(context: HookContext) -> None:
     message = (
-        f"Cutting snapshot '{context.resources.snapshot_config.snapshot_name}' "
-        f"for dataset '{context.resources.snapshot_config.dataset_name}'.\n"
+        f"Cutting snapshot `{context.resources.snapshot_config.snapshot_name}`\n"
+        f"Dataset: `{context.resources.snapshot_config.dataset_name}`\n"
         f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
@@ -89,8 +89,8 @@ def snapshot_start_notification(context: HookContext) -> None:
 )
 def snapshot_job_failed_notification(context: HookContext) -> None:
     message = (
-        f"FAILED to cut snapshot '{context.resources.snapshot_config.snapshot_name}' "
-        f"for dataset '{context.resources.snapshot_config.dataset_name}!\n"
+        f"*FAILED to cut snapshot* `{context.resources.snapshot_config.snapshot_name}`\n"
+        f"Dataset `{context.resources.snapshot_config.dataset_name}`"
         f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
@@ -102,8 +102,8 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
 )
 def message_for_snapshot_done(context: HookContext) -> None:
     message = (
-        f"COMPLETED snapshot '{context.resources.snapshot_config.snapshot_name}' "
-        f"for dataset '{context.resources.snapshot_config.dataset_name}'.\n"
+        f"*COMPLETED snapshot* `{context.resources.snapshot_config.snapshot_name}`\n"
+        f"Dataset `{context.resources.snapshot_config.dataset_name}`\n"
         f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -76,8 +76,8 @@ test_mode = ModeDefinition(
 )
 def snapshot_start_notification(context: HookContext) -> None:
     message = (
-        f"Cutting snapshot `{context.resources.snapshot_config.snapshot_name}`\n"
-        f"Dataset: `{context.resources.snapshot_config.dataset_name}`\n"
+        f"Cutting snapshot '{context.resources.snapshot_config.snapshot_name}' "
+        f"for dataset '{context.resources.snapshot_config.dataset_name}'.\n"
         f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
@@ -89,8 +89,8 @@ def snapshot_start_notification(context: HookContext) -> None:
 )
 def snapshot_job_failed_notification(context: HookContext) -> None:
     message = (
-        f"*FAILED to cut snapshot* `{context.resources.snapshot_config.snapshot_name}`\n"
-        f"Dataset `{context.resources.snapshot_config.dataset_name}`"
+        f"FAILED to cut snapshot '{context.resources.snapshot_config.snapshot_name}' "
+        f"for dataset '{context.resources.snapshot_config.dataset_name}!\n"
         f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 
@@ -102,8 +102,8 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
 )
 def message_for_snapshot_done(context: HookContext) -> None:
     message = (
-        f"*COMPLETED snapshot* `{context.resources.snapshot_config.snapshot_name}`\n"
-        f"Dataset `{context.resources.snapshot_config.dataset_name}`\n"
+        f"COMPLETED snapshot '{context.resources.snapshot_config.snapshot_name}' "
+        f"for dataset '{context.resources.snapshot_config.dataset_name}'.\n"
         f"<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>"
     )
 

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
@@ -1,15 +1,12 @@
 import os
 import unittest
-import uuid
 from typing import Any
 from unittest.mock import patch
 
-import pytest
 from dagster import execute_pipeline, file_relative_path, PipelineDefinition, PipelineExecutionResult
 from dagster.utils import load_yaml_from_globs
 from dagster.utils.merger import deep_merge_dicts
 
-from hca_manage.diff_dirs import diff_dirs
 from hca_orchestration.pipelines import load_hca, validate_egress
 
 
@@ -43,40 +40,6 @@ class PipelinesTestCase(unittest.TestCase):
             run_config=config_dict,
             mode=pipeline_mode
         )
-
-    @pytest.mark.skip
-    @pytest.mark.e2e
-    def test_load_hca_local_e2e(self):
-        test_id = f'test-{uuid.uuid4()}'
-        runtime_config = {
-            'resources': {
-                'beam_runner': {
-                    'config': {
-                        'working_dir': beam_runner_path()
-                    }
-                },
-                'scratch_config': {
-                    'config': {
-                        'scratch_prefix_name': f'local-stage-data/{test_id}'
-                    }
-                }
-            }
-        }
-
-        self.run_pipeline(
-            load_hca,
-            'test_load_hca_local_e2e.yaml',
-            extra_config=runtime_config,
-            pipeline_mode='local')
-
-        expected_blobs, output_blobs = diff_dirs(
-            'broad-dsp-monster-hca-dev',
-            'broad-dsp-monster-hca-dev-test-storage',
-            'integration/ebi_small/expected_output',
-            'broad-dsp-monster-hca-dev-temp-storage',
-            f'local-stage-data/{test_id}',
-        )
-        self.assertEqual(expected_blobs, output_blobs, "Output results differ from expected")
 
     def test_load_data_noop_resources(self):
         result = self.run_pipeline(load_hca, config_name="test_load_hca_noop_resources.yaml")

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
@@ -1,12 +1,15 @@
 import os
 import unittest
+import uuid
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from dagster import execute_pipeline, file_relative_path, PipelineDefinition, PipelineExecutionResult
 from dagster.utils import load_yaml_from_globs
 from dagster.utils.merger import deep_merge_dicts
 
+from hca_manage.diff_dirs import diff_dirs
 from hca_orchestration.pipelines import load_hca, validate_egress
 
 
@@ -24,11 +27,11 @@ def beam_runner_path() -> str:
 
 class PipelinesTestCase(unittest.TestCase):
     def run_pipeline(
-        self,
-        pipeline: PipelineDefinition,
-        config_name: str,
-        extra_config: dict[str, Any] = {},
-        pipeline_mode='test'
+            self,
+            pipeline: PipelineDefinition,
+            config_name: str,
+            extra_config: dict[str, Any] = {},
+            pipeline_mode='test'
     ) -> PipelineExecutionResult:
         config_dict = load_yaml_from_globs(
             config_path(config_name)
@@ -40,6 +43,40 @@ class PipelinesTestCase(unittest.TestCase):
             run_config=config_dict,
             mode=pipeline_mode
         )
+
+    @pytest.mark.skip
+    @pytest.mark.e2e
+    def test_load_hca_local_e2e(self):
+        test_id = f'test-{uuid.uuid4()}'
+        runtime_config = {
+            'resources': {
+                'beam_runner': {
+                    'config': {
+                        'working_dir': beam_runner_path()
+                    }
+                },
+                'scratch_config': {
+                    'config': {
+                        'scratch_prefix_name': f'local-stage-data/{test_id}'
+                    }
+                }
+            }
+        }
+
+        self.run_pipeline(
+            load_hca,
+            'test_load_hca_local_e2e.yaml',
+            extra_config=runtime_config,
+            pipeline_mode='local')
+
+        expected_blobs, output_blobs = diff_dirs(
+            'broad-dsp-monster-hca-dev',
+            'broad-dsp-monster-hca-dev-test-storage',
+            'integration/ebi_small/expected_output',
+            'broad-dsp-monster-hca-dev-temp-storage',
+            f'local-stage-data/{test_id}',
+        )
+        self.assertEqual(expected_blobs, output_blobs, "Output results differ from expected")
 
     def test_load_data_noop_resources(self):
         result = self.run_pipeline(load_hca, config_name="test_load_hca_noop_resources.yaml")


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1763)
We need to auto-generate the HCA schema when creating an HCA dataset, rather than relying on pulling it down via a well-known gist every time.

## This PR
* My original plan was to just glob up the schema JSON files from the `schema` module in HCA. However, those schemas are not in a format consumable by Jade. As part of our build process, we apply a scala plugin that does the needed transformation. I've decided to delegate the schema generation to that task and run it via a `subprocess.run()` call if the needed schema json is not present. This isn't going to be _great_ for CI, but it establishes a `generate_schema` interface that we can iterate on and allows us to proceed with the creation of the needed E2E test which this ticket is positioned to enable.
* Refactors the argument handling to use subparsers rather than argument groups. Argument groups are awkward for the purposes of this script (i.e., both "create" and "query" consume the dataset name argument, but we were re-purposing the remove version which is confusing. A subparser gives us a cleaner separate between the 3 modes of this script.
* Extracts the `_exec_tdr_operation` wrapper to a formal decorator in `.common` which we can reuse if need be.


