### PR TITLE
Ability to query for snapshots

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/common.py
+++ b/orchestration/dagster_orchestration/hca_manage/common.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 from dataclasses import dataclass
+import logging
 import functools
 import sys
 from typing import Any, Callable, NoReturn, TextIO, TypeVar, cast
@@ -14,6 +15,17 @@ from data_repo_client import ApiClient, Configuration, RepositoryApi, ApiExcepti
 
 make_python_type_usable_as_dagster_type(JobId, DagsterString)
 
+data_repo_host = {
+    "dev": "https://jade.datarepo-dev.broadinstitute.org/",
+    "prod": "https://jade-terra.datarepo-prod.broadinstitute.org/",
+    "real_prod": "https://data.terra.bio/"
+}
+
+data_repo_profile_ids = {
+    "dev": "390e7a85-d47f-4531-b612-165fc977d3bd",
+    "prod": "db61c343-6dfe-4d14-84e9-60ddf97ea73f"
+}
+
 
 @dataclass
 class ProblemCount:
@@ -25,16 +37,8 @@ class ProblemCount:
         return self.duplicates > 0 or self.null_file_refs > 0 or self.dangling_project_refs > 0
 
 
-data_repo_host = {
-    "dev": "https://jade.datarepo-dev.broadinstitute.org/",
-    "prod": "https://jade-terra.datarepo-prod.broadinstitute.org/",
-    "real_prod": "https://data.terra.bio/"
-}
-
-data_repo_profile_ids = {
-    "dev": "390e7a85-d47f-4531-b612-165fc977d3bd",
-    "prod": "db61c343-6dfe-4d14-84e9-60ddf97ea73f"
-}
+def setup_cli_logging_format() -> None:
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
 class DefaultHelpParser(argparse.ArgumentParser):

--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -12,7 +12,7 @@ from dagster_utils.contrib.data_repo.typing import JobId
 from data_repo_client import RepositoryApi, EnumerateDatasetModel
 
 from hca_manage import __version__ as hca_manage_version
-from hca_manage.common import data_repo_host, DefaultHelpParser, get_api_client, query_yes_no, tdr_operation
+from hca_manage.common import data_repo_host, DefaultHelpParser, get_api_client, query_yes_no, tdr_operation, setup_cli_logging_format
 
 MAX_DATASET_CREATE_POLL_SECONDS = 120
 DATASET_CREATE_POLL_INTERVAL_SECONDS = 2
@@ -21,6 +21,7 @@ logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
 def run(arguments: Optional[list[str]] = None) -> None:
+    setup_cli_logging_format()
     parser = DefaultHelpParser(description="A simple CLI to manage TDR datasets.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)
     parser.add_argument("-e", "--env", help="The Jade environment to target",

--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -9,12 +9,11 @@ from dagster_utils.contrib.data_repo.typing import JobId
 
 from hca_manage import __version__ as hca_manage_version
 from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelpParser, get_api_client, \
-    query_yes_no, tdr_operation
-
-logging.basicConfig(level=logging.INFO, format='%(message)s')
+    query_yes_no, tdr_operation, setup_cli_logging_format
 
 
 def run(arguments: Optional[list[str]] = None) -> None:
+    setup_cli_logging_format()
     parser = DefaultHelpParser(description="A simple CLI to manage TDR snapshots.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)
     parser.add_argument("-e", "--env", help="The Jade environment to target", choices=["dev", "prod"], required=True)

--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -4,63 +4,73 @@ from datetime import datetime, date
 import logging
 from typing import Optional
 
-from data_repo_client import RepositoryApi, SnapshotRequestModel, SnapshotRequestContentsModel
+from data_repo_client import RepositoryApi, SnapshotRequestModel, SnapshotRequestContentsModel, EnumerateSnapshotModel
 from dagster_utils.contrib.data_repo.typing import JobId
 
 from hca_manage import __version__ as hca_manage_version
-from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelpParser, get_api_client,\
-    query_yes_no
+from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelpParser, get_api_client, \
+    query_yes_no, tdr_operation
 
-
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format='%(message)s')
 
 
 def run(arguments: Optional[list[str]] = None) -> None:
     parser = DefaultHelpParser(description="A simple CLI to manage TDR snapshots.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)
     parser.add_argument("-e", "--env", help="The Jade environment to target", choices=["dev", "prod"], required=True)
-
-    snapshot_flags = parser.add_mutually_exclusive_group(required=True)
-    snapshot_flags.add_argument("-c", "--create", help="Flag to create a snapshot", action="store_true")
-    snapshot_flags.add_argument("-r", "--remove", help="Flag to delete a snapshot", action="store_true")
+    subparsers = parser.add_subparsers()
 
     # create
-    snapshot_create_args = parser.add_argument_group()
-    snapshot_create_args.add_argument("-d", "--dataset", help="The Jade dataset to target")
-    snapshot_create_args.add_argument("-q", "--qualifier", help="Optional qualifier to append to the snapshot name")
+    snapshot_create = subparsers.add_parser("create")
+    snapshot_create.add_argument("-d", "--dataset", help="The Jade dataset to target")
+    snapshot_create.add_argument("-q", "--qualifier", help="Optional qualifier to append to the snapshot name")
+    snapshot_create.set_defaults(func=_create_snapshot)
 
-    # delete
-    snapshot_delete_args = parser.add_mutually_exclusive_group(required=True)
-    snapshot_delete_args.add_argument("-n", "--snapshot_name", help="Name of snapshot to delete.")
-    snapshot_delete_args.add_argument("-i", "--snapshot_id", help="ID of snapshot to delete.")
+    # remove
+    snapshot_delete = subparsers.add_parser("remove")
+    snapshot_delete.add_argument("-n", "--snapshot_name", help="Name of snapshot to delete.")
+    snapshot_delete.add_argument("-i", "--snapshot_id", help="ID of snapshot to delete.")
+    snapshot_delete.set_defaults(func=_remove_snapshot)
+
+    snapshot_query = subparsers.add_parser("query")
+    snapshot_query.add_argument("-n", "--snapshot_name", help="Name of snapshot to filter for")
+    snapshot_query.set_defaults(func=_query_snapshot)
 
     args = parser.parse_args(arguments)
+    args.func(args)
+
+
+@tdr_operation
+def _create_snapshot(args: argparse.Namespace) -> None:
+    if not query_yes_no("Are you sure?"):
+        return
+
     host = data_repo_host[args.env]
-
-    if args.remove:
-        if query_yes_no("Are you sure?"):
-            remove_snapshot(args, host)
-        else:
-            # TODO change to logger?
-            print("No deletion attempted.")
-    elif args.create:
-        if query_yes_no("This will create a snapshot. Are you sure?"):
-            create_snapshot(args, host)
-
-
-def create_snapshot(args: argparse.Namespace, host: str) -> JobId:
     profile_id = data_repo_profile_ids[args.env]
     hca = SnapshotManager(
         environment=args.env,
         dataset=args.dataset,
         data_repo_profile_id=profile_id,
         data_repo_client=get_api_client(host=host))
-    return hca.submit_snapshot_request(qualifier=args.qualifier)
+    hca.submit_snapshot_request(qualifier=args.qualifier)
 
 
-def remove_snapshot(args: argparse.Namespace, host: str) -> JobId:
+@tdr_operation
+def _remove_snapshot(args: argparse.Namespace) -> None:
+    if not query_yes_no("Are you sure?"):
+        return
+
+    host = data_repo_host[args.env]
     hca = SnapshotManager(environment=args.env, data_repo_client=get_api_client(host=host))
-    return hca.delete_snapshot(snapshot_name=args.snapshot_name, snapshot_id=args.snapshot_id)
+    hca.delete_snapshot(snapshot_name=args.snapshot_name, snapshot_id=args.snapshot_id)
+
+
+@tdr_operation
+def _query_snapshot(args: argparse.Namespace) -> None:
+    host = data_repo_host[args.env]
+
+    hca = SnapshotManager(environment=args.env, data_repo_client=get_api_client(host=host))
+    logging.info(hca.query_snapshot(snapshot_name=args.snapshot_name))
 
 
 @dataclass
@@ -78,9 +88,9 @@ class SnapshotManager:
         }[self.environment]
 
     def submit_snapshot_request(
-        self,
-        qualifier: Optional[str] = None,
-        snapshot_date: Optional[date] = None,
+            self,
+            qualifier: Optional[str] = None,
+            snapshot_date: Optional[date] = None,
     ) -> JobId:
         snapshot_date = snapshot_date or datetime.today().date()
         return self.submit_snapshot_request_with_name(self.snapshot_name(qualifier, snapshot_date))
@@ -140,3 +150,10 @@ class SnapshotManager:
         job_id: JobId = self.data_repo_client.delete_snapshot(snapshot_id).id
         logging.info(f"Snapshot deletion job id: {job_id}")
         return job_id
+
+    def query_snapshot(self, snapshot_name: Optional[str] = None) -> EnumerateSnapshotModel:
+        return self.data_repo_client.enumerate_snapshots(filter=snapshot_name)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Why

We often need to query for snapshots, this adds the ability to our hca_manage tool so we don't have to go to the swagger page.

## This PR
* Adds the needed query method which hits the `enumerateSnapshots` endpoint
* Adds back the ability to create a dataset with a pre-baked JSON schema file, which I need for DAP TDR testing.
* Updates arg parsing in the `snapshots.py` file to use subparsers rather than mutually exclusive arg groups, bringing it in line with the approach I took in `dataset.py`.
* Minor cleanups in `dataset.py` 

