### PR TITLE
[DSPDC-1791] Parameterize jade data project rather than pulling from configmap values

### DIFF
--- a/orchestration/templates/import-hca-no-files.yaml
+++ b/orchestration/templates/import-hca-no-files.yaml
@@ -8,6 +8,10 @@ spec:
     parameters:
       - name: data-repo-name
         {{- $dataRepoName := "{{workflow.parameters.data-repo-name}}" }}
+      - name: data-repo-name
+        {{- $dataRepoUrl := "{{workflow.parameters.data-repo-url}}" }}
+      - name: data-repo-billing-profile-id
+        {{- $dataRepoBillingProfileId := "{{workflow.parameters.data-repo-billing-profile-id}}" }}
       - name: dataset-id
         {{- $datasetId := "{{workflow.parameters.dataset-id}}" }}
   serviceAccountName: {{ .Values.serviceAccount.k8sName }}
@@ -52,3 +56,7 @@ spec:
                   value: {{ $datasetId | quote }}
                 - name: staging-bucket-prefix
                   value: {{ $stagingPrefix | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
+                - name: data-repo-billing-profile-id
+                  value: {{ $dataRepoBillingProfileId | quote }}

--- a/orchestration/templates/import-hca-total.yaml
+++ b/orchestration/templates/import-hca-total.yaml
@@ -51,7 +51,7 @@ spec:
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
                 - name: data-repo-project
-                  value: { { $dataRepoProject | quote } }
+                  value: {{ $dataRepoProject | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: staging-bucket-prefix

--- a/orchestration/templates/import-hca-total.yaml
+++ b/orchestration/templates/import-hca-total.yaml
@@ -8,6 +8,8 @@ spec:
     parameters:
       - name: data-repo-name
         {{- $dataRepoName := "{{workflow.parameters.data-repo-name}}" }}
+      - name: data-repo-project
+        {{- $dataRepoProject := "{{workflow.parameters.data-repo-project}}" }}
       - name: dataset-id
         {{- $datasetId := "{{workflow.parameters.dataset-id}}" }}
   serviceAccountName: {{ .Values.serviceAccount.k8sName }}
@@ -48,6 +50,8 @@ spec:
               parameters:
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: { { $dataRepoProject | quote } }
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: staging-bucket-prefix

--- a/orchestration/templates/import-hca-total.yaml
+++ b/orchestration/templates/import-hca-total.yaml
@@ -10,6 +10,10 @@ spec:
         {{- $dataRepoName := "{{workflow.parameters.data-repo-name}}" }}
       - name: data-repo-project
         {{- $dataRepoProject := "{{workflow.parameters.data-repo-project}}" }}
+      - name: data-repo-url
+        {{- $dataRepoUrl := "{{workflow.parameters.data-repo-url}}" }}
+      - name: data-repo-billing-profile-id
+        {{- $dataRepoBillingProfileId := "{{workflow.parameters.data-repo-billing-profile-id}}" }}
       - name: dataset-id
         {{- $datasetId := "{{workflow.parameters.dataset-id}}" }}
   serviceAccountName: {{ .Values.serviceAccount.k8sName }}
@@ -52,6 +56,10 @@ spec:
                   value: {{ $dataRepoName | quote }}
                 - name: data-repo-project
                   value: {{ $dataRepoProject | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
+                - name: data-repo-billing-profile-id
+                  value: {{ $dataRepoBillingProfileId | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: staging-bucket-prefix

--- a/orchestration/templates/load-hca-no-files.yaml
+++ b/orchestration/templates/load-hca-no-files.yaml
@@ -13,6 +13,8 @@ spec:
             {{- $dataRepoName := "{{inputs.parameters.data-repo-name}}" }}
           - name: data-repo-project
             {{- $dataRepoProject := "{{inputs.parameters.data-repo-project}}" }}
+          - name: data-repo-url
+            {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
             {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: staging-bucket-prefix

--- a/orchestration/templates/load-hca-no-files.yaml
+++ b/orchestration/templates/load-hca-no-files.yaml
@@ -11,6 +11,8 @@ spec:
         parameters:
           - name: data-repo-name
             {{- $dataRepoName := "{{inputs.parameters.data-repo-name}}" }}
+          - name: data-repo-project
+            {{- $dataRepoProject := "{{inputs.parameters.data-repo-project}}" }}
           - name: dataset-id
             {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: staging-bucket-prefix
@@ -83,5 +85,7 @@ spec:
                   value: {{ $datasetName | quote }}
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: {{ $dataRepoProject | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -15,6 +15,10 @@ spec:
             {{- $dataRepoProject := "{{inputs.parameters.data-repo-project}}" }}
           - name: dataset-id
             {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
+          - name: data-repo-url
+            {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
+          - name: data-repo-billing-profile-id
+            {{- $dataRepoBillingProfileId := "{{inputs.parameters.data-repo-billing-profile-id}}" }}
           - name: staging-bucket-prefix
           {{- $stagingPrefix := "{{inputs.parameters.staging-bucket-prefix}}" }}
           - name: source-bucket-name
@@ -89,6 +93,8 @@ spec:
                   value: {{ $dataRepoName | quote }}
                 - name: data-repo-project
                   value: {{ $dataRepoProject | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
 
@@ -157,6 +163,10 @@ spec:
                   value: {{ $totalLoadCount | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
+                - name: data-repo-billing-profile-id
+                  value: {{ $dataRepoBillingProfileId | quote }}
 
           - name: ingest-file-metadata
             dependencies: [ingest-data-files]
@@ -252,6 +262,8 @@ spec:
           - name: total-file-count
           {{- $totalFileCount := "{{inputs.parameters.total-file-count}}" }}
           - name: dataset-id
+          - name: data-repo-url
+          - name: data-repo-billing-profile-id
       dag:
         tasks:
           - name: submit
@@ -277,7 +289,7 @@ spec:
                   value: {{ $jobId | quote }}
                 {{- with .Values.repo }}
                 - name: api-url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: timeout
                   value: {{ .pollTimeout | quote }}
                 - name: sa-secret
@@ -293,6 +305,8 @@ spec:
               parameters:
                 - name: job-id
                   value: {{ $jobId | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
 
     ##
     ## Submit a bulk-file ingest using a request staged in GCS.
@@ -325,11 +339,11 @@ spec:
             value: {{ $maxFailures | quote }}
           {{- with .Values.repo }}
           - name: API_URL
-            value: {{ .url }}
+            value: {{ $dataRepoUrl | quote }}
           - name: DATASET_ID
             value: {{ $datasetId | quote }}
           - name: PROFILE_ID
-            value: {{ .profileId }}
+            value: {{ $dataRepoBillingProfileId | quote }}
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: {{ printf "/secret/%s" .accessKey.secretKey }}
           {{- end }}
@@ -363,7 +377,7 @@ spec:
           - name: JOB_ID
             value: {{ $jobId | quote }}
           - name: API_URL
-            value: {{ .Values.repo.url }}
+            value: {{ $dataRepoUrl | quote }}
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: {{ printf "/secret/%s" .Values.repo.accessKey.secretKey }}
         command: [python]
@@ -449,6 +463,8 @@ spec:
                   value: {{ $dataRepoName | quote }}
                 - name: data-repo-project
                   value: {{ $dataRepoProject | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
 

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -280,6 +280,10 @@ spec:
                   value: 0
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
+                - name: data-repo-billing-profile-id
+                  value: {{ $dataRepoBillingProfileId | quote }}
           {{- $jobId := "{{tasks.submit.outputs.result}}" }}
 
           - name: poll
@@ -323,6 +327,8 @@ spec:
           - name: max-failures
           {{- $maxFailures := "{{inputs.parameters.max-failures}}" }}
           - name: dataset-id
+          - name: data-repo-url
+          - name: data-repo-billing-profile-id
       volumes:
         - name: sa-secret-volume
           secret:

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -263,7 +263,9 @@ spec:
           {{- $totalFileCount := "{{inputs.parameters.total-file-count}}" }}
           - name: dataset-id
           - name: data-repo-url
+          {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: data-repo-billing-profile-id
+          {{- $dataRepoBillingProfileId := "{{inputs.parameters.data-repo-billing-profile-id}}" }}
       dag:
         tasks:
           - name: submit

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -11,6 +11,8 @@ spec:
         parameters:
           - name: data-repo-name
             {{- $dataRepoName := "{{inputs.parameters.data-repo-name}}" }}
+          - name: data-repo-project
+            {{- $dataRepoProject := "{{inputs.parameters.data-repo-project}}" }}
           - name: dataset-id
             {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: staging-bucket-prefix
@@ -189,6 +191,7 @@ spec:
           - name: staging-bq-dataset
           {{- $bqDataset := "{{inputs.parameters.staging-bq-dataset}}" }}
           - name: data-repo-name
+          - name: data-repo-project
       script:
         image: google/cloud-sdk:slim
         env:
@@ -201,7 +204,7 @@ spec:
           - name: STAGING_DATASET
             value: {{ $bqDataset | quote }}
           - name: JADE_PROJECT
-            value: {{ .Values.bigquery.jadeData.project }}
+            value: {{ $dataRepoProject | quote }}
           - name: JADE_DATASET
             value: {{ $dataRepoName | quote }}
         command: [bash]
@@ -451,6 +454,7 @@ spec:
           - name: bq-dataset
           {{- $bqDataset := "{{inputs.parameters.bq-dataset}}" }}
           - name: data-repo-name
+          - name: data-repo-project
           - name: source-prefix
           {{- $sourcePrefix := "{{inputs.parameters.source-prefix}}" }}
       script:
@@ -467,7 +471,7 @@ spec:
           - name: STAGING_DATASET
             value: {{ $bqDataset | quote }}
           - name: JADE_PROJECT
-            value: {{ .Values.bigquery.jadeData.project }}
+            value: {{ $dataRepoProject | quote }}
           - name: JADE_DATASET
             value: {{ $dataRepoName | quote }}
         command: [bash]

--- a/orchestration/templates/load-hca.yaml
+++ b/orchestration/templates/load-hca.yaml
@@ -87,6 +87,8 @@ spec:
                   value: {{ $datasetName | quote }}
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: {{ $dataRepoProject | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
 
@@ -105,6 +107,8 @@ spec:
                   value: {{ $datasetName | quote }}
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: {{ $dataRepoProject | quote }}
 
           {{- $outputFileLoadPrefix := printf "%s/data-transfer-requests-deduped" $stagingPrefix }}
           - name: extract-file-loads
@@ -173,6 +177,8 @@ spec:
                   value: {{ $datasetName | quote }}
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: {{ $dataRepoProject | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: source-prefix
@@ -377,6 +383,7 @@ spec:
           - name: bq-dataset
           {{- $bqDataset := "{{inputs.parameters.bq-dataset}}" }}
           - name: data-repo-name
+          - name: data-repo-project
           - name: dataset-id
           - name: source-prefix
           {{- $sourcePrefix := "{{inputs.parameters.source-prefix}}" }}
@@ -394,6 +401,8 @@ spec:
                   value: {{ $bqDataset | quote }}
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: {{ $dataRepoProject | quote }}
                 - name: source-prefix
                   value: {{ $sourcePrefix | quote }}
           {{- $fileIdsTable := "{{tasks.inject-file-ids.outputs.result}}" }}
@@ -438,6 +447,8 @@ spec:
                   value: {{ $bqDataset | quote }}
                 - name: data-repo-name
                   value: {{ $dataRepoName | quote }}
+                - name: data-repo-project
+                  value: {{ $dataRepoProject | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
 

--- a/orchestration/templates/load-table.yaml
+++ b/orchestration/templates/load-table.yaml
@@ -19,6 +19,8 @@ spec:
           {{- $bqDataset := "{{inputs.parameters.bq-dataset}}" }}
           - name: data-repo-name
           {{- $dataRepoName := "{{inputs.parameters.data-repo-name}}" }}
+          - name: data-repo-project
+          {{- $dataRepoProject := "{{inputs.parameters.data-repo-project}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
       dag:
@@ -46,7 +48,7 @@ spec:
                   - name: staging-bq-dataset
                     value: {{ $bqDataset | quote }}
                   - name: jade-bq-project
-                    value: {{ .Values.bigquery.jadeData.project }}
+                    value: {{ $dataRepoProject | quote }}
                   - name: jade-bq-dataset
                     value: {{ $dataRepoName | quote }}
                   - name: diff-full-history
@@ -154,6 +156,7 @@ spec:
           - name: staging-bq-dataset
           {{- $bqDataset := "{{inputs.parameters.staging-bq-dataset}}" }}
           - name: data-repo-name
+          - name: data-repo-project
       script:
         image: google/cloud-sdk:slim
         env:
@@ -164,7 +167,7 @@ spec:
           - name: STAGING_DATASET
             value: {{ $bqDataset | quote }}
           - name: JADE_PROJECT
-            value: {{ .Values.bigquery.jadeData.project }}
+            value: {{ $dataRepoProject | quote }}
           - name: JADE_DATASET
             value: {{ $dataRepoName | quote }}
         command: [bash]

--- a/orchestration/templates/load-table.yaml
+++ b/orchestration/templates/load-table.yaml
@@ -93,6 +93,8 @@ spec:
                     value: {{ $bqDataset | quote }}
                   - name: data-repo-name
                     value: {{ $dataRepoName | quote }}
+                  - name: data-repo-project
+                    value: {{ $dataRepoProject | quote }}
                   {{- $outdatedIdsTable := "{{tasks.get-outdated-ids.outputs.result}}" }}
 
             {{- $outdatedIdsPrefix := printf "%s/outdated-ids/%s" $stagingPrefix $table }}

--- a/orchestration/templates/load-table.yaml
+++ b/orchestration/templates/load-table.yaml
@@ -21,6 +21,8 @@ spec:
           {{- $dataRepoName := "{{inputs.parameters.data-repo-name}}" }}
           - name: data-repo-project
           {{- $dataRepoProject := "{{inputs.parameters.data-repo-project}}" }}
+          - name: data-repo-url
+          {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
       dag:
@@ -71,7 +73,7 @@ spec:
                     value: {{ .Values.gcs.stagingBucketName }}
                   {{- with .Values.repo }}
                   - name: url
-                    value: {{ .url }}
+                    value: {{ $dataRepoUrl | quote }}
                   - name: dataset-id
                     value: {{ $datasetId | quote }}
                   - name: timeout
@@ -135,7 +137,7 @@ spec:
                     value: {{ .Values.gcs.stagingBucketName }}
                   {{- with .Values.repo }}
                   - name: url
-                    value: {{ .url }}
+                    value: {{ $dataRepoUrl | quote }}
                   - name: dataset-id
                     value: {{ $datasetId | quote }}
                   - name: timeout

--- a/orchestration/workflows/prod/run-import-hca-total.yaml
+++ b/orchestration/workflows/prod/run-import-hca-total.yaml
@@ -13,6 +13,7 @@ spec:
       - name: staging-bucket-prefix
       - name: dataset-id
       - name: data-repo-name
+      - name: data-repo-project
   templates:
     - name: main
       templateRef:

--- a/orchestration/workflows/prod/run-import-hca-total.yaml
+++ b/orchestration/workflows/prod/run-import-hca-total.yaml
@@ -14,6 +14,8 @@ spec:
       - name: dataset-id
       - name: data-repo-name
       - name: data-repo-project
+      - name: data-repo-url
+      - name: data-repo-billing-profile-id
   templates:
     - name: main
       templateRef:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,9 +6,13 @@ val publishPatterns = Patterns()
   .withIvyPatterns(Vector(s"$patternBase/ivy-[revision].xml"))
   .withArtifactPatterns(Vector(s"$patternBase/[module]-[revision](-[classifier]).[ext]"))
 
-resolvers += Resolver.url(
-  "Broad Artifactory",
-  new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
-)(publishPatterns)
+//resolvers += Resolver.url(
+//  "Broad Artifactory",
+//  new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
+//)(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")
+
+resolvers += Resolver.mavenLocal
+
+
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.10-0-0f366386-20210607-0900-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,13 +6,9 @@ val publishPatterns = Patterns()
   .withIvyPatterns(Vector(s"$patternBase/ivy-[revision].xml"))
   .withArtifactPatterns(Vector(s"$patternBase/[module]-[revision](-[classifier]).[ext]"))
 
-//resolvers += Resolver.url(
-//  "Broad Artifactory",
-//  new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
-//)(publishPatterns)
+resolvers += Resolver.url(
+  "Broad Artifactory",
+  new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
+)(publishPatterns)
 
-
-resolvers += Resolver.mavenLocal
-
-
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.10-0-0f366386-20210607-0900-SNAPSHOT")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")

--- a/scripts/release_tools/import_prod.sh
+++ b/scripts/release_tools/import_prod.sh
@@ -33,4 +33,5 @@ argo submit ../../orchestration/workflows/prod/run-import-hca-total.yaml \
      -p source-bucket-prefix="$SOURCE_BUCKET_PREFIX" \
      -p staging-bucket-prefix="$STAGING_BUCKET" \
      -p dataset-id="d30e68f8-c826-4639-88f3-ae35f00d4185" \
-     -p data-repo-name="datarepo_hca_prod_20201120_dcp2"
+     -p data-repo-name="datarepo_hca_prod_20201120_dcp2" \
+     -p data-repo-project="broad-datarepo-terra-prod-hca2"

--- a/scripts/release_tools/import_prod.sh
+++ b/scripts/release_tools/import_prod.sh
@@ -34,4 +34,6 @@ argo submit ../../orchestration/workflows/prod/run-import-hca-total.yaml \
      -p staging-bucket-prefix="$STAGING_BUCKET" \
      -p dataset-id="d30e68f8-c826-4639-88f3-ae35f00d4185" \
      -p data-repo-name="datarepo_hca_prod_20201120_dcp2" \
-     -p data-repo-project="broad-datarepo-terra-prod-hca2"
+     -p data-repo-project="broad-datarepo-terra-prod-hca2" \
+     -p data-repo-billing-profile-id="db61c343-6dfe-4d14-84e9-60ddf97ea73f" \
+     -p data-repo-url="https://jade-terra.datarepo-prod.broadinstitute.org"


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1791)
We are loading LungMap data to a different dataset in "real" prod, which means the owning BQ project is going to differ from what is currently hardcoded in the `jadeData` configmap.

## This PR
* Parameterizes the jade BQ project

