### PR TITLE
[DSPDC-1738] Upgrade ingest-utils version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ resolvers += Resolver.url(
 // useful when testing ingest-utils locally
 resolvers += Resolver.mavenLocal
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.10")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.11")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,7 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")
+// useful when testing ingest-utils locally
+resolvers += Resolver.mavenLocal
+
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.10")


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1738)
We need to be up to date with upstream dependencies like Beam and Scio.

## This PR
* Upgrades the ingest-utils version to 2.1.11

