### PR TITLE
[DSPDC-1766] Thread through region when creating a dataset

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -45,6 +45,7 @@ class DatasetManagerTestCase(unittest.TestCase):
             "fake_billing_id",
             {"abc@example.com", "def@example.com"},
             {"fake": "schema"},
+            "us-east4",
             None
         )
 

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -48,6 +48,7 @@ def dataset_id(dataset_name, delete_dataset_on_exit, existing_dataset_id) -> Ite
             data_repo_profile_ids["dev"],
             None,
             dataset_manager.generate_schema(),
+            "US",
             MONSTER_TEST_DATASET_SENTINEL
         )
 


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1766)
We should not hardcode "US" when creating datasets as we will not _always_ want them in that multi-region.

## This PR
* Parameterizes the region
* Updates affected tests

