### PR TITLE
Fix Job tool to work in both the result and job use case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.autoenv.zsh
 target/
 .scalafmt.conf
 .idea

--- a/orchestration/dagster_orchestration/hca_manage/billing_profile.py
+++ b/orchestration/dagster_orchestration/hca_manage/billing_profile.py
@@ -20,6 +20,9 @@ def run(arguments: Optional[list[str]] = None) -> None:
     billing_profile_create.add_argument("-n", "--profile_name", required=True)
     billing_profile_create.set_defaults(func=_create_billing_profile)
 
+    billing_profile_query = subparsers.add_parser("enumerate")
+    billing_profile_query.set_defaults(func=_enumerate_billing_profiles)
+
     args = parser.parse_args(arguments)
     args.func(args)
 
@@ -42,6 +45,15 @@ def _create_billing_profile(args: argparse.Namespace) -> None:
     )
 
     logging.info(f"Billing profile creation response = {response}")
+
+
+def _enumerate_billing_profiles(args: argparse.Namespace) -> None:
+    host = data_repo_host[args.env]
+    resources_api_client = get_resources_api_client(host)
+
+    response = resources_api_client.enumerate_profiles()
+
+    logging.info(response)
 
 
 if __name__ == '__main__':

--- a/orchestration/dagster_orchestration/hca_manage/job.py
+++ b/orchestration/dagster_orchestration/hca_manage/job.py
@@ -5,12 +5,11 @@ TDR job inspection tool. Fetches the job status, and optionally the result
 import logging
 import json
 
-from hca_manage.common import DefaultHelpParser, get_api_client, data_repo_host
-
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+from hca_manage.common import DefaultHelpParser, get_api_client, data_repo_host, setup_cli_logging_format
 
 
 def fetch_job_info() -> None:
+    setup_cli_logging_format()
     parser = DefaultHelpParser(description="A simple CLI to inspect TDR jobs.")
 
     parser.add_argument("-e", "--env", help="The Jade environment to target",

--- a/orchestration/dagster_orchestration/hca_manage/job.py
+++ b/orchestration/dagster_orchestration/hca_manage/job.py
@@ -28,9 +28,9 @@ def fetch_job_info() -> None:
 
     if args.fetch_result:
         result = data_repo_client.retrieve_job_result(args.job_id)
+        logging.info(json.dumps(result, indent=4))
     else:
-        result = data_repo_client.retrieve_job(args.job_id)
-    logging.info(json.dumps(result, indent=4))
+        logging.info(data_repo_client.retrieve_job(args.job_id))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Why

(No relevant ticket)
I bumped into some wonkiness when polling jobs locally. We were expecting to be able to JSON serialize the result which in both "retrieveJobResult" and "retrieveJob" modes, which is not the case.

## This PR
* Only json serializes job results, not the job model
* Adds a .gitignore entry for autoenv which I've been using to good effect.
* Adds an "enumerate" mode for billing profiles 

