### PR TITLE
Do not pass certain params when calling jade prod

### DIFF
--- a/ops/helmfiles/dagster/forward_ports.sh
+++ b/ops/helmfiles/dagster/forward_ports.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This script forwards port 8080 to the Kubernetes cluster running our Dagster install so you can access
 # the Dagit dashboard from your machine.
+set -e
 ENV=${1:-dev}
 
 echo $ENV

--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -226,7 +226,7 @@ class DatasetManager:
         """
         Enumerates TDR datasets, filtering on the given dataset_name
         """
-        return self.data_repo_client.enumerate_datasets(filter=dataset_name)
+        return self.data_repo_client.enumerate_datasets(filter=dataset_name, limit=1000)
 
     def add_policy_members(
             self,

--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -188,7 +188,7 @@ class DatasetManager:
             "cloudPlatform": "gcp"
         }
 
-        if env == 'prod':
+        if env == "prod":
             # Jade "prod" does not support these args
             payload.pop("region")
             payload.pop("cloudPlatform")

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -46,6 +46,7 @@ class DatasetManagerTestCase(unittest.TestCase):
             {"abc@example.com", "def@example.com"},
             {"fake": "schema"},
             "us-east4",
+            "dev",
             None
         )
 

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -49,6 +49,7 @@ def dataset_id(dataset_name, delete_dataset_on_exit, existing_dataset_id) -> Ite
             None,
             dataset_manager.generate_schema(),
             "US",
+            "dev",
             MONSTER_TEST_DATASET_SENTINEL
         )
 


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1791)
We ended up provisioning the LungMap dataset in the Jade prod env. This uncovered some incompatibilities in our dataset creation code, specifically two parameters that are not supported in that environment.

## This PR
* Conditionally removes the parameters if the dataset creation call is being made against Jade `prod`

