### PR TITLE
Fire slack notification on dagster deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 target/
 .scalafmt.conf
 .idea
-.swp
+*.swp
 .metals/
 project/metals.sbt
 .bloop/


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1833)
We should notify slack with the rev, user and environment when dagster is deployed.x

## This PR
* Adds a slack notification to the `apply.sh` script
* Updates the `.gitignore` file to properly ignore vim `.swp` files

## Checklist
- [x] Documentation has been updated as needed.
