### PR TITLE
Bump data file ingest timeout

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/poll_ingest_job.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/load_hca/poll_ingest_job.py
@@ -37,7 +37,7 @@ def check_data_ingest_job_result(config: DagsterConfigDict) -> DagsterConfigDict
     Any files failed will fail the pipeline
     """
     return {
-        'max_wait_time_seconds': 600,  # 10 minutes
+        'max_wait_time_seconds': 28800,  # 8 hours
         'poll_interval_seconds': 5
     }
 


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1814)
We are running into timeouts ingesting data files with the standard 10 minute timeout.

## This PR
* Bumps the timeout to 8 hours

## Checklist
- [ ] Documentation has been updated as needed.
