### PR TITLE
Auto add monster as a steward when creating datasets

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -114,12 +114,12 @@ def _query_dataset(args: argparse.Namespace) -> None:
 class DatasetManager:
     environment: str
     data_repo_client: RepositoryApi
-    steward_list: list[str] = field(init=False)
+    stewards: set[str] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.steward_list = {
-            "dev": ["monster@firecloud.org"],
-            "prod": ["monster@firecloud.org"]
+        self.stewards = {
+            "dev": {"monster@firecloud.org"},
+            "prod": {"monster@firecloud.org"}
         }[self.environment]
 
     def generate_schema(self) -> dict[str, object]:
@@ -175,7 +175,7 @@ class DatasetManager:
         # if policy-members are provided in the CLI args, add the monster team email (default without provided arg)
         if policy_members:
             logging.info(f"Adding policy_members {policy_members}")
-            self.add_policy_members(dataset_id, self.steward_list, "steward")
+            self.add_policy_members(dataset_id, self.stewards, "steward")
             self.add_policy_members(dataset_id, policy_members, "steward")
 
         return dataset_id

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -51,7 +51,7 @@ class DatasetManagerTestCase(unittest.TestCase):
         )
 
         self.manager.data_repo_client.create_dataset.assert_called_once()
-        self.assertEqual(self.manager.data_repo_client.add_dataset_policy_member.call_count, 2)
+        self.assertEqual(self.manager.data_repo_client.add_dataset_policy_member.call_count, 3)
 
     def test_valid_dataset_name(self):
         _validate_dataset_name(

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, call
 
 from data_repo_client import RepositoryApi
 
@@ -51,7 +51,12 @@ class DatasetManagerTestCase(unittest.TestCase):
         )
 
         self.manager.data_repo_client.create_dataset.assert_called_once()
-        self.assertEqual(self.manager.data_repo_client.add_dataset_policy_member.call_count, 3)
+        calls = [
+            call('fake_dataset_id', policy_name='steward', policy_member={'email': 'monster@firecloud.org'}),
+            call('fake_dataset_id', policy_name='steward', policy_member={'email': 'abc@example.com'}),
+            call('fake_dataset_id', policy_name='steward', policy_member={'email': 'def@example.com'}),
+        ]
+        self.manager.data_repo_client.add_dataset_policy_member.assert_has_calls(calls, any_order=True)
 
     def test_valid_dataset_name(self):
         _validate_dataset_name(


### PR DESCRIPTION
## Why
Ensure that _monster@firecloud.org_ is auto added as a policy member when creating datasets in order to make sure the whole team can access datasets, snapshots, and profiles in TDR.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1839)

## This PR
- Added the monster team email as the default value to the the policy-members CLI arguments for creating a dataset
- Added an init method to add the monster team email to a list of stewards which is included when adding policy_members
- Updated the unit test to make sure we auto added the monster team email and called the add dataset policy member function 3 times

## Checklist
- [ ] Documentation has been updated as needed.
