### PR TITLE
[DSPDC-1827] Validate snapshot name

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -20,6 +20,10 @@ DATASET_CREATE_POLL_INTERVAL_SECONDS = 2
 DATASET_NAME_REGEX = "^hca_(dev|prod|staging)_(\\d{4})(\\d{2})(\\d{2})(_[a-zA-Z][a-zA-Z0-9]{0,13})?$"
 
 
+class InvalidDatasetNameException(ValueError):
+    pass
+
+
 def run(arguments: Optional[list[str]] = None) -> None:
     setup_cli_logging_format()
     parser = DefaultHelpParser(description="A simple CLI to manage TDR datasets.")
@@ -67,7 +71,7 @@ def _remove_dataset(args: argparse.Namespace) -> None:
 # validate provided name against dataset name regex from the spec
 def _validate_dataset_name(dataset_name: str) -> None:
     if not search(DATASET_NAME_REGEX, dataset_name):
-        raise ValueError("The provided dataset name is not up to spec.")
+        raise InvalidDatasetNameException(f"Dataset name {dataset_name} is invalid")
 
 
 @tdr_operation

--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -2,7 +2,7 @@ import argparse
 from dataclasses import dataclass, field
 from datetime import datetime, date
 import logging
-import re
+from re import search
 import sys
 from typing import Optional
 
@@ -16,7 +16,7 @@ from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelp
 
 MAX_SNAPSHOT_DELETE_POLL_SECONDS = 120
 SNAPSHOT_DELETE_POLL_INTERVAL_SECONDS = 2
-VALIDATE_SNAPSHOT_NAME_REGEX = r"^hca_(dev|prod|staging)_(\d{4})(\d{2})(\d{2})(_[a-zA-Z][a-zA-Z0-9]{0,13})?_([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})?__(\d{4})(\d{2})(\d{2})(?:_([a-zA-Z][a-zA-Z0-9]{0,13}))?$"
+SNAPSHOT_NAME_REGEX = r"^hca_(dev|prod|staging)_(\d{4})(\d{2})(\d{2})(_[a-zA-Z][a-zA-Z0-9]{0,13})?_([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})?__(\d{4})(\d{2})(\d{2})(?:_([a-zA-Z][a-zA-Z0-9]{0,13}))?$"
 
 
 class InvalidSnapshotNameException(ValueError):
@@ -116,7 +116,7 @@ class SnapshotManager:
         :param snapshot_name: name of snapshot to create
         :return: Job ID of the snapshot creation job
         """
-        if not re.findall(VALIDATE_SNAPSHOT_NAME_REGEX, snapshot_name):
+        if not search(SNAPSHOT_NAME_REGEX, snapshot_name):
             raise InvalidSnapshotNameException(f"Snapshot name {snapshot_name} is invalid")
 
         snapshot_request = SnapshotRequestModel(

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock
 
 from data_repo_client import RepositoryApi
 
-from hca_manage.dataset import DatasetManager, _validate_dataset_name
+from hca_manage.dataset import DatasetManager, _validate_dataset_name, InvalidDatasetNameException
 
 
 class DatasetManagerTestCase(unittest.TestCase):
@@ -59,7 +59,7 @@ class DatasetManagerTestCase(unittest.TestCase):
         )
 
     def test_invalid_dataset_name(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidDatasetNameException):
             _validate_dataset_name(
                 "fake_dataset_name"
             )

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_snapshot_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_snapshot_manager.py
@@ -1,4 +1,3 @@
-
 import unittest
 from unittest.mock import MagicMock, Mock
 


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSDPC-1827) There is a spec for HCA snapshot names, we should adhere to it when creating snapshots.

## This PR
* Adds a check against the regex from the DCP2 spec and raises if the supplied name does not match
* Updates dataset name validation code to be consistent with the approach for the snapshot name validation
* Adds and updates tests
## Checklist
- [x] Documentation has been updated as needed.
