### PR TITLE
Add snapshot retrieval and snapshot policy update operations

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -6,7 +6,8 @@ from re import search
 import sys
 from typing import Optional
 
-from data_repo_client import RepositoryApi, SnapshotRequestModel, SnapshotRequestContentsModel, EnumerateSnapshotModel, PolicyMemberRequest
+from data_repo_client import RepositoryApi, SnapshotRequestModel, SnapshotRequestContentsModel, \
+    EnumerateSnapshotModel, PolicyMemberRequest, PolicyResponse
 from dagster_utils.contrib.data_repo.jobs import poll_job, JobPollException
 from dagster_utils.contrib.data_repo.typing import JobId
 
@@ -230,12 +231,11 @@ class SnapshotManager:
     def query_snapshot(self, snapshot_name: Optional[str] = None) -> EnumerateSnapshotModel:
         return self.data_repo_client.enumerate_snapshots(filter=snapshot_name, limit=1000)
 
-    def add_policy_member(self, policy_member: str, policy_name: str, snapshot_id: str) -> None:
+    def add_policy_member(self, policy_member: str, policy_name: str, snapshot_id: str) -> PolicyResponse:
         payload = PolicyMemberRequest(email=policy_member)
-        response = self.data_repo_client.add_snapshot_policy_member(snapshot_id, policy_name, policy_member=payload)
-        return response
+        return self.data_repo_client.add_snapshot_policy_member(snapshot_id, policy_name, policy_member=payload)
 
-    def retrieve_policies(self, snapshot_id: str):
+    def retrieve_policies(self, snapshot_id: str) -> PolicyResponse:
         return self.data_repo_client.retrieve_snapshot_policies(id=snapshot_id)
 
 

--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -143,7 +143,7 @@ class SnapshotManager:
 
     def __post_init__(self) -> None:
         self.reader_list = {
-            "dev": ["hca-snapshot-readers@dev.test.firecloud.org"],
+            "dev": ["hca-snapshot-readers@dev.test.firecloud.org", "monster-dev@dev.test.firecloud.org"],
             "prod": ["hca-snapshot-readers@firecloud.org", "monster@firecloud.org"]
         }[self.environment]
 

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/config/data_repo.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/config/data_repo.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from dagster import resource, String
+from dagster import resource, String, Bool
 from dagster.core.execution.context.init import InitResourceContext
 
 
@@ -8,11 +8,13 @@ from dagster.core.execution.context.init import InitResourceContext
 class SnapshotCreationConfig:
     dataset_name: str
     snapshot_name: str
+    managed_access: bool
 
 
 @resource({
     'dataset_name': String,
     'snapshot_name': String,
+    'managed_access': Bool
 })
 def snapshot_creation_config(init_context: InitResourceContext) -> SnapshotCreationConfig:
     return SnapshotCreationConfig(**init_context.resource_config)

--- a/orchestration/dagster_orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/solids/create_snapshot.py
@@ -16,7 +16,10 @@ def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
         dataset=context.resources.snapshot_config.dataset_name,
         data_repo_client=context.resources.data_repo_client,
         data_repo_profile_id=data_repo_profile_ids[context.resources.hca_manage_config.gcp_env],
-    ).submit_snapshot_request_with_name(context.resources.snapshot_config.snapshot_name)
+    ).submit_snapshot_request_with_name(
+        context.resources.snapshot_config.snapshot_name,
+        context.resources.snapshot_config.managed_access
+    )
 
 
 @solid(

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/solids/test_create_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/solids/test_create_snapshot.py
@@ -20,7 +20,8 @@ class CreateSnapshotSolidsTestCase(unittest.TestCase):
                         'snapshot_config': {
                             'config': {
                                 'dataset_name': 'badset',
-                                'snapshot_name': 'namityname'
+                                'snapshot_name': 'namityname',
+                                'managed_access': False
                             }
                         }
                     }
@@ -28,7 +29,7 @@ class CreateSnapshotSolidsTestCase(unittest.TestCase):
             )
             self.assertTrue(result.success)
             self.assertEqual(result.output_value(), JobId('abcde'))
-            submit_snap.assert_called_once_with('namityname')
+            submit_snap.assert_called_once_with('namityname', False)
 
     def test_make_snapshot_public_hits_correct_sam_path(self):
         with patch('dagster_utils.resources.sam.NoopSamClient.make_snapshot_public') as mock_make_public:


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1860)
We need the ability to add policy members to a snapshot.

## This PR
* Adds CLI options to our snapshot tool that enable querying and adding snapshot policy members
* Customizes the snapshot policy members based on a new `managed_access` bool and threads that through to the relevant pipeline code

## Checklist
- [x] Documentation has been updated as needed.
