### PR TITLE
[DSPDC-1869] Use correct GCP project name

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/config/resources/k8s_dataflow_beam_runner/prod.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/resources/k8s_dataflow_beam_runner/prod.yaml
@@ -1,3 +1,3 @@
 temp_bucket: broad-dsp-monster-hca-prod-temp-storage
-service_account: hca-dataflow-runner@broad-dsp-monster-hca-prod.iam.gserviceaccount.com
-project: broad-dsp-monster-hca-prod
+service_account: hca-dataflow-runner@mystical-slate-284720.iam.gserviceaccount.com
+project: mystical-slate-284720


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1869)
We need to use the correct GCP project name when firing off dataflow jobs.

## This PR
* Updates the project name

## Checklist
- [ ] Documentation has been updated as needed.
