### PR TITLE
Attempting to fix master ci

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install dependencies
-        run: poetry install --no-dev
+        run: poetry install
         working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
       - uses: olafurpg/setup-scala@v10
         with:


### PR DESCRIPTION
## Why

Master CI is busted due to a [file not found error](https://github.com/DataBiosphere/hca-ingest/runs/3220816442)
I believe this is because we do not install python dev deps in master CI and thus pytest is not present.

## This PR
* Removes the `--no-dev` arg as a band-aid

## Checklist
- [x] Documentation has been updated as needed.
