### PR TITLE
Fix CI slowness by setting request timeout on fixture dataset deletion

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -254,7 +254,7 @@ class DatasetManager:
         else:
             # can't have both/neither provided
             raise ValueError("You must provide either dataset_name or dataset_id, and cannot provide neither/both.")
-        delete_response_id: JobId = self.data_repo_client.delete_dataset(dataset_id).id
+        delete_response_id: JobId = self.data_repo_client.delete_dataset(dataset_id, _request_timeout=30).id
         logging.info(f"Dataset deletion job id: {delete_response_id}")
         return delete_response_id
 

--- a/orchestration/dagster_orchestration/hca_manage/dataset.py
+++ b/orchestration/dagster_orchestration/hca_manage/dataset.py
@@ -254,6 +254,10 @@ class DatasetManager:
         else:
             # can't have both/neither provided
             raise ValueError("You must provide either dataset_name or dataset_id, and cannot provide neither/both.")
+
+        # set a request timeout (read + connect) of 30 seconds; for unknown reasons, this call can hang for
+        # minutes in our CI environment. Setting a timeout here forces a quick failure + an immediate
+        # (hoppefully successful) retry
         delete_response_id: JobId = self.data_repo_client.delete_dataset(dataset_id, _request_timeout=30).id
         logging.info(f"Dataset deletion job id: {delete_response_id}")
         return delete_response_id

--- a/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
+++ b/orchestration/dagster_orchestration/hca_manage/tests/test_dataset_manager.py
@@ -22,12 +22,12 @@ class DatasetManagerTestCase(unittest.TestCase):
 
         self.manager.delete_dataset(dataset_name='steve')
 
-        self.manager.data_repo_client.delete_dataset.assert_called_once_with('abc')
+        self.manager.data_repo_client.delete_dataset.assert_called_once_with('abc', _request_timeout=30)
 
     def test_delete_dataset_uses_id_if_provided(self):
         self.manager.delete_dataset(dataset_id='steve')
 
-        self.manager.data_repo_client.delete_dataset.assert_called_once_with('steve')
+        self.manager.data_repo_client.delete_dataset.assert_called_once_with('steve', _request_timeout=30)
 
     def test_delete_dataset_blows_up_if_both_or_neither_id_and_name(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1876)
CI is taking upwards of 30 minutes to complete. I've tracked this down to the fixture dataset deletion request we are making to TDR. Specifically, there is no timeout set in our calls to the client, so I believe `urllib3` under the hood is using the default system socket timeouts. It's still unclear why this call would take _minutes_.

## This PR
* Adds a 30 second timeout to the `delete_dataset` call. This causes a quick failure and then a retry which immediately succeeds.

## Checklist
- [ ] Documentation has been updated as needed.
