### PR TITLE
Fix e2e testing

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -50,7 +50,7 @@ def dataset_info(dataset_name, delete_dataset_on_exit, existing_dataset_id) -> I
         dataset_id = existing_dataset_id
     else:
         logging.info("No existing dataset ID passed, creating new dataset")
-        dataset_id = dataset_manager.create_dataset_with_policy_members(
+        info = dataset_manager.create_dataset_with_policy_members(
             dataset_name,
             data_repo_profile_ids["dev"],
             None,
@@ -58,7 +58,8 @@ def dataset_info(dataset_name, delete_dataset_on_exit, existing_dataset_id) -> I
             "US",
             "dev",
             MONSTER_TEST_DATASET_SENTINEL
-        ).id
+        )
+        dataset_id = info.id
 
     info = dataset_manager.retrieve_dataset(dataset_id)
     yield DatasetInfo(dataset_id, info.data_project)

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -58,7 +58,7 @@ def dataset_info(dataset_name, delete_dataset_on_exit, existing_dataset_id) -> I
             "US",
             "dev",
             MONSTER_TEST_DATASET_SENTINEL
-        )
+        ).id
 
     info = dataset_manager.retrieve_dataset(dataset_id)
     yield DatasetInfo(dataset_id, info.data_project)


### PR DESCRIPTION

## Why

The return type of the create dataset method changed, and the e2e tests are failing because of it.

## This PR
* Updates the fixture setup and teardown for e2e to reflect these changes.

