### PR TITLE
Tool to find project row IDs in TDR

### DIFF
--- a/ops/helmfiles/dagster/helmfile.lock
+++ b/ops/helmfiles/dagster/helmfile.lock
@@ -5,7 +5,7 @@ dependencies:
   version: 0.0.6
 - name: dagster
   repository: https://dagster-io.github.io/helm
-  version: 0.12.13
+  version: 0.12.3
 - name: serviceaccount-psp
   repository: https://broadinstitute.github.io/datarepo-helm
   version: 0.0.3

--- a/orchestration/dagster_orchestration/hca_manage/find_project_rows.py
+++ b/orchestration/dagster_orchestration/hca_manage/find_project_rows.py
@@ -47,7 +47,8 @@ def _query_for_project(args: argparse.Namespace) -> None:
 
     logging.info("Project row IDs = ")
     project_row_ids = bq_service.build_query_job(query, bq_project_id).result()
-    [logging.info(row["datarepo_row_id"]) for row in project_row_ids]
+    for row in project_row_ids:
+        logging.info(row["datarepo_row_id"])
 
     query = f"""
     SELECT * FROM `datarepo_{dataset_name}.links`
@@ -56,7 +57,8 @@ def _query_for_project(args: argparse.Namespace) -> None:
     links_rows = bq_service.build_query_job(query, bq_project_id).result()
     logging.info("")
     logging.info("Links row IDs = ")
-    [logging.info(row["datarepo_row_id"]) for row in links_rows]
+    for row in links_rows:
+        logging.info(row["datarepo_row_id"])
 
 
 if __name__ == '__main__':

--- a/orchestration/dagster_orchestration/hca_manage/find_project_rows.py
+++ b/orchestration/dagster_orchestration/hca_manage/find_project_rows.py
@@ -1,0 +1,63 @@
+"""
+Queries the given dataset for a project_id and returns the related
+datarepo_row_ids from the project + links table.
+
+This is useful when used in concert with soft deletion to remove a
+project from the dataset that should not have been imported. This
+_will_ leave garbage behind (i.e., other related entities from the
+subgraphs, files, etc.), but will do enough to suppress surfacing the
+project in the browser and prevent it from being publicly viewable.
+
+TODO: Automate out the soft deletion process
+"""
+
+import argparse
+import logging
+from typing import Optional
+
+from google.cloud.bigquery import Client
+
+from hca_manage.common import setup_cli_logging_format, DefaultHelpParser
+from hca_orchestration.contrib.bigquery import BigQueryService
+
+
+def run(arguments: Optional[list[str]] = None) -> None:
+    setup_cli_logging_format()
+
+    parser = DefaultHelpParser("Finds projects in HCA")
+
+    parser.add_argument("-p", "--hca_project_id", required=True)
+    parser.add_argument("-d", "--dataset_name", required=True)
+    parser.add_argument("-b", "--bq_project_id", required=True)
+
+    args = parser.parse_args(arguments)
+    _query_for_project(args)
+
+
+def _query_for_project(args: argparse.Namespace) -> None:
+    dataset_name = args.dataset_name
+    hca_project_id = args.hca_project_id
+    bq_project_id = args.bq_project_id
+
+    bq_service = BigQueryService(Client())
+    query = f"""
+    SELECT * FROM `datarepo_{dataset_name}.project`
+    WHERE project_id = '{hca_project_id}'
+    """
+
+    logging.info("Project row IDs = ")
+    project_row_ids = bq_service.build_query_job(query, bq_project_id).result()
+    [logging.info(row["datarepo_row_id"]) for row in project_row_ids]
+
+    query = f"""
+    SELECT * FROM `datarepo_{dataset_name}.links`
+    WHERE project_id = '{hca_project_id}'
+    """
+    links_rows = bq_service.build_query_job(query, bq_project_id).result()
+    logging.info("")
+    logging.info("Links row IDs = ")
+    [logging.info(row["datarepo_row_id"]) for row in links_rows]
+
+
+if __name__ == '__main__':
+    run()

--- a/orchestration/dagster_orchestration/hca_manage/soft_delete.py
+++ b/orchestration/dagster_orchestration/hca_manage/soft_delete.py
@@ -118,3 +118,7 @@ class SoftDeleteManager:
         )
 
         return JobId(response.id)  # type: ignore # data repo client has no type hints, since it's auto-generated
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1879)
There was an issue in DCP8 where a project was included for import that should not have been. The fix in these cases is to
find the related datarepo_row_ids in the `project` and `links` tables and submit them for soft deletion. This is an attempt
to script up the first part of that process so we don't have to adjourn to the BQ web console every time this happens.

## This PR
* Adds a `find_project_rows.py` script that outputs the `project` and `links` `datarepo_row_ids` in question.

## Checklist
- [ ] Documentation has been updated as needed.
