### PR TITLE
Include Google Project ID in snapshot slack notifications

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -96,7 +96,7 @@ def snapshot_start_notification(context: HookContext) -> None:
     job_id = context.solid_output_values["result"]
     kvs = {
         "Snapshot name": context.resources.snapshot_config.snapshot_name,
-        "Project ID": context.resources.hca_manage_config.google_project_name,
+        "Google Project ID": context.resources.hca_manage_config.google_project_name,
         "Dataset": context.resources.snapshot_config.dataset_name,
         "TDR Job ID": job_id,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
@@ -117,7 +117,7 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
 
     kvs = {
         "Snapshot name": context.resources.snapshot_config.snapshot_name,
-        "Project ID": context.resources.hca_manage_config.google_project_name,
+        "Google Project ID": context.resources.hca_manage_config.google_project_name,
         "Dataset": context.resources.snapshot_config.dataset_name,
         "TDR Job ID": job_id,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
@@ -132,7 +132,7 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
 def message_for_snapshot_done(context: HookContext) -> None:
     context.resources.slack.send_message(blocks=key_value_slack_blocks("HCA Snapshot Complete", {
         "Snapshot name": context.resources.snapshot_config.snapshot_name,
-        "Project ID": context.resources.hca_manage_config.google_project_name,
+        "Google Project ID": context.resources.hca_manage_config.google_project_name,
         "Dataset": context.resources.snapshot_config.dataset_name,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
     }))

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -89,13 +89,14 @@ test_mode = ModeDefinition(
 
 
 @success_hook(
-    required_resource_keys={'slack', 'snapshot_config', 'dagit_config'}
+    required_resource_keys={'slack', 'snapshot_config', 'dagit_config', 'hca_manage_config'}
 )
 def snapshot_start_notification(context: HookContext) -> None:
     context.log.info(f"Solid output = {context.solid_output_values}")
     job_id = context.solid_output_values["result"]
     kvs = {
         "Snapshot name": context.resources.snapshot_config.snapshot_name,
+        "Project ID": context.resources.hca_manage_config.google_project_name,
         "Dataset": context.resources.snapshot_config.dataset_name,
         "TDR Job ID": job_id,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
@@ -106,7 +107,7 @@ def snapshot_start_notification(context: HookContext) -> None:
 
 
 @failure_hook(
-    required_resource_keys={'slack', 'snapshot_config', 'dagit_config'}
+    required_resource_keys={'slack', 'snapshot_config', 'dagit_config', 'hca_manage_config'}
 )
 def snapshot_job_failed_notification(context: HookContext) -> None:
     if "result" in context.solid_output_values:
@@ -116,6 +117,7 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
 
     kvs = {
         "Snapshot name": context.resources.snapshot_config.snapshot_name,
+        "Project ID": context.resources.hca_manage_config.google_project_name,
         "Dataset": context.resources.snapshot_config.dataset_name,
         "TDR Job ID": job_id,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
@@ -125,11 +127,12 @@ def snapshot_job_failed_notification(context: HookContext) -> None:
 
 
 @success_hook(
-    required_resource_keys={'slack', 'snapshot_config', 'dagit_config'}
+    required_resource_keys={'slack', 'snapshot_config', 'dagit_config', 'hca_manage_config'}
 )
 def message_for_snapshot_done(context: HookContext) -> None:
     context.resources.slack.send_message(blocks=key_value_slack_blocks("HCA Snapshot Complete", {
         "Snapshot name": context.resources.snapshot_config.snapshot_name,
+        "Project ID": context.resources.hca_manage_config.google_project_name,
         "Dataset": context.resources.snapshot_config.dataset_name,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
     }))

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
@@ -2,6 +2,6 @@ resources:
   snapshot_config:
     config:
       dataset_name: 'hca_prod_20201120_dcp2'
-      snapshot_name: 'hca_prod_20201120_dcp2___20210812_dcp8'
+      snapshot_name: 'hca_prod_20201120_dcp2___20210812_fake'
       managed_access: False
 

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
@@ -1,0 +1,7 @@
+resources:
+  snapshot_config:
+    config:
+      dataset_name: 'hca_prod_20201120_dcp2'
+      snapshot_name: 'hca_prod_20201120_dcp2___20210812_dcp8'
+      managed_access: False
+

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
@@ -74,7 +74,7 @@ class PipelinesTestCase(unittest.TestCase):
         result = self.run_pipeline(cut_snapshot, config_name="test_create_snapshot.yaml")
 
         self.assertTrue(result.success)
-        # todo: a test case for invalid snapshot name assertRaises(InvalidSnapshotNameException)?
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/tests/test_pipelines.py
@@ -7,7 +7,8 @@ from dagster import execute_pipeline, file_relative_path, PipelineDefinition, Pi
 from dagster.utils import load_yaml_from_globs
 from dagster.utils.merger import deep_merge_dicts
 
-from hca_orchestration.pipelines import load_hca, validate_egress
+from hca_orchestration.pipelines import cut_snapshot, load_hca, validate_egress
+from hca_manage.snapshot import InvalidSnapshotNameException
 
 
 def config_path(relative_path: str) -> str:
@@ -66,6 +67,14 @@ class PipelinesTestCase(unittest.TestCase):
 
         self.assertTrue(result.success)
 
+    def test_cut_snapshot(self):
+        """
+        This test is checking to see if cut_snapshot spins up
+        """
+        result = self.run_pipeline(cut_snapshot, config_name="test_create_snapshot.yaml")
+
+        self.assertTrue(result.success)
+        # todo: a test case for invalid snapshot name assertRaises(InvalidSnapshotNameException)?
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Why
We need to include the Google project ID in the snapshot completion notification.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1881)

## This PR
- Added project ID (pulled from the hca_manage_config context to the snapshot notification messages.
- Added a test for the cut_snapshot pipeline in the test_pipelines file.
- Added a test config for the cut_snapshot test.

## Checklist
- [x] Documentation has been updated as needed.
