### PR TITLE
load_hca completion slack notification

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
@@ -108,11 +108,13 @@ def import_start_notification(context: HookContext) -> None:
 
     context.resources.slack.send_message(blocks=key_value_slack_blocks("HCA Starting Import", key_values=kvs))
 
-@success_hook(
+
+@solid(
     required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config'}
 )
-def import_complete_notification(context: HookContext) -> None:
-    context.log.info(f"Solid output = {context.solid_output_values}")
+def terminal_solid(context: HookContext, results1: list[Optional[JobId]], results2: list[Optional[JobId]]) -> None:
+    # todo: do I need to log the solid output here?
+    # context.log.info(f"Solid output = {context.solid_output_values}")
     kvs = {
         # todo: how do I pull staging area out here (that is from the preprocess_metadata solid config)
         # "Staging area": context.solid_config["input_prefix"],
@@ -120,14 +122,8 @@ def import_complete_notification(context: HookContext) -> None:
         "Jade Project": context.resources.target_hca_dataset.project_id,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'
     }
-
     context.resources.slack.send_message(blocks=key_value_slack_blocks("HCA Completed Import", key_values=kvs))
 
-@solid
-def terminal_solid(results1: list[Optional[JobId]], results2: list[Optional[JobId]]) -> None:
-    # todo: should there be a check for whether we get valid results?
-    # if (results1 is not None and results2 is not None):
-    pass
 
 @pipeline(
     mode_defs=[prod_mode, dev_mode, local_mode, test_mode]
@@ -141,5 +137,4 @@ def load_hca() -> None:
     file_metadata_results = file_metadata_fanout(result, staging_dataset).collect()
     non_file_metadata_results = non_file_metadata_fanout(result, staging_dataset).collect()
 
-    hooked_terminal_solid = terminal_solid.with_hooks({import_complete_notification})
-    hooked_terminal_solid(file_metadata_results, non_file_metadata_results)
+    terminal_solid(file_metadata_results, non_file_metadata_results)

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
@@ -1,5 +1,6 @@
 from dagster import HookContext, solid, Optional, ResourceDefinition
 from dagster import ModeDefinition, pipeline, success_hook
+from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 from dagster_gcp.gcs import gcs_pickle_io_manager
 from dagster_utils.contrib.data_repo.typing import JobId
 from dagster_utils.resources.beam.k8s_beam_runner import k8s_dataflow_beam_runner
@@ -112,12 +113,10 @@ def import_start_notification(context: HookContext) -> None:
 @solid(
     required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config'}
 )
-def terminal_solid(context: HookContext, results1: list[Optional[JobId]], results2: list[Optional[JobId]]) -> None:
-    # todo: do I need to log the solid output here?
-    # context.log.info(f"Solid output = {context.solid_output_values}")
+def terminal_solid(context: AbstractComputeExecutionContext,
+                   results1: list[Optional[JobId]], results2: list[Optional[JobId]]) -> None:
     kvs = {
-        # todo: how do I pull staging area out here (that is from the preprocess_metadata solid config)
-        # "Staging area": context.solid_config["input_prefix"],
+        "Staging area": context.run_config["solids"]["pre_process_metadata"]["config"]["input_prefix"],
         "Target Dataset": context.resources.target_hca_dataset.dataset_name,
         "Jade Project": context.resources.target_hca_dataset.project_id,
         "Dagit link": f'<{context.resources.dagit_config.run_url(context.run_id)}|View in Dagit>'

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/load_hca.py
@@ -113,8 +113,11 @@ def import_start_notification(context: HookContext) -> None:
 @solid(
     required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config'}
 )
-def terminal_solid(context: AbstractComputeExecutionContext,
-                   results1: list[Optional[JobId]], results2: list[Optional[JobId]]) -> None:
+def terminal_solid(
+        context: AbstractComputeExecutionContext,
+        results1: list[Optional[JobId]],
+        results2: list[Optional[JobId]]
+) -> None:
     kvs = {
         "Staging area": context.run_config["solids"]["pre_process_metadata"]["config"]["input_prefix"],
         "Target Dataset": context.resources.target_hca_dataset.dataset_name,


### PR DESCRIPTION
## Why
We should be notified in #monster-ci when a load_hca import starts and when it finishes.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/dspdc-1872)

## This PR
Added a success hook to send a slack notification upon successful completion of the load_hca pipeline

## Checklist
- [ ] Documentation has been updated as needed.
