### PR TITLE
[DSPDC-1890] Add partitioning logic

### DIFF
--- a/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/dev_refresh.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/dev_refresh.py
@@ -1,0 +1,41 @@
+"""
+Defines partitioning logic for the Q3 2021 dev refresh
+"""
+
+import os
+
+from dagster import file_relative_path, Partition, PartitionSetDefinition
+from dagster.utils import load_yaml_from_path
+
+
+def get_dev_refresh_partitions() -> list[Partition]:
+    path = file_relative_path(
+        __file__, os.path.join("./partitions/", "hca_project_ids.csv")
+    )
+
+    with open(path) as project_ids_file:
+        lines = project_ids_file.readlines()
+        project_ids = [Partition(project_id.strip()) for project_id in lines]
+
+    return project_ids
+
+
+def run_config_for_dev_refresh_partition(partition: Partition):
+    path = file_relative_path(
+        __file__, os.path.join("./run_config", "run_config.yaml")
+    )
+    run_config = load_yaml_from_path(path)
+    run_config["resources"]["hca_project_copying_config"]["config"]["source_hca_project_id"] = partition.value
+    run_config["resources"]["load_tag"]["config"]["load_tag_prefix"] = f"dev_refresh_project_{partition.value}"
+    run_config["resources"]["scratch_config"]["config"]["scratch_prefix_name"] = f"project_copy_{partition.value}"
+
+    return run_config
+
+
+def dev_refresh_partition_set() -> PartitionSetDefinition:
+    return PartitionSetDefinition(
+        name="dev_refresh_partition_set",
+        pipeline_name="copy_project",
+        partition_fn=get_dev_refresh_partitions,
+        run_config_fn_for_partition=run_config_for_dev_refresh_partition
+    )

--- a/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/dev_refresh.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/dev_refresh.py
@@ -6,6 +6,7 @@ import os
 
 from dagster import file_relative_path, Partition, PartitionSetDefinition
 from dagster.utils import load_yaml_from_path
+from dagster_utils.typing import DagsterObjectConfigSchema
 
 
 def get_dev_refresh_partitions() -> list[Partition]:
@@ -20,11 +21,11 @@ def get_dev_refresh_partitions() -> list[Partition]:
     return project_ids
 
 
-def run_config_for_dev_refresh_partition(partition: Partition):
+def run_config_for_dev_refresh_partition(partition: Partition) -> DagsterObjectConfigSchema:
     path = file_relative_path(
         __file__, os.path.join("./run_config", "run_config.yaml")
     )
-    run_config = load_yaml_from_path(path)
+    run_config: DagsterObjectConfigSchema = load_yaml_from_path(path)
     run_config["resources"]["hca_project_copying_config"]["config"]["source_hca_project_id"] = partition.value
     run_config["resources"]["load_tag"]["config"]["load_tag_prefix"] = f"dev_refresh_project_{partition.value}"
     run_config["resources"]["scratch_config"]["config"]["scratch_prefix_name"] = f"project_copy_{partition.value}"

--- a/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/run_config/run_config.yaml
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/run_config/run_config.yaml
@@ -1,0 +1,22 @@
+resources:
+  hca_project_copying_config:
+    config:
+      source_bigquery_project_id: tdr-prd1-87360b54
+      source_snapshot_name: hca_prod_20201120_dcp2___20210812_dcp8
+  load_tag:
+    config:
+      append_timestamp: true
+      load_tag_prefix: project_copy
+  scratch_config:
+    config:
+      scratch_bq_project: NA
+      scratch_bucket_name: broad-dsp-monster-hca-dev-temp-storage
+      scratch_dataset_prefix: NA
+      scratch_table_expiration_ms: 0
+  target_hca_dataset:
+    config:
+      billing_profile_id: 390e7a85-d47f-4531-b612-165fc977d3bd
+      dataset_id: 38d2d4aa-6fac-4ea1-b430-a225d0377846
+      dataset_name: hca_dev_20210817_arhtesting
+      project_id: datarepo-dev-2dfd8993
+

--- a/orchestration/dagster_orchestration/hca_orchestration/repositories.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/repositories.py
@@ -1,11 +1,11 @@
+import os
 from typing import Union
 
 from dagster import PipelineDefinition, repository, SensorDefinition
 
-from hca_orchestration.sensors import build_post_import_sensor
+from hca_orchestration.config.dev_refresh.dev_refresh import dev_refresh_partition_set
 from hca_orchestration.pipelines import copy_project, cut_snapshot, load_hca, validate_egress
-
-import os
+from hca_orchestration.sensors import build_post_import_sensor
 
 
 @repository
@@ -15,6 +15,7 @@ def hca_orchestrationtype() -> list[Union[PipelineDefinition, SensorDefinition]]
         load_hca,
         validate_egress,
         build_post_import_sensor(os.environ.get("ENV", "test")),
-        copy_project
+        copy_project,
+        dev_refresh_partition_set()
     ]
     return defs


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1890)
We should use dagster's partitioning backfill feature to let it automate the load of the 137 projects for the dev refresh.

## This PR
* Puts the list of projects in a CSV that we parse and hand to dagster as our definition of the partition set
* Adds a mostly hardcoded run config which we will need to adjust as dataset's change etc. I'm not particularly fond of the hardcoding of this config as it'll require a PR + deploy if any part of the config changes (i.e, the target dataset for instance).

## Checklist
- [ ] Documentation has been updated as needed.
