### PR TITLE
Connect to the correct k8s cluster on deploy

### DIFF
--- a/ops/helmfiles/dagster/apply.sh
+++ b/ops/helmfiles/dagster/apply.sh
@@ -61,5 +61,5 @@ else
 	gcloud container clusters get-credentials hca-cluster --project broad-dsp-monster-hca-dev --region us-central1-c
 fi
 
-helmfile $COMMAND
+helmfile --interactive $COMMAND
 fire_slack_deployment_notification ${ENV} ${GIT_SHORTHASH}


### PR DESCRIPTION
## Why

Helmfile will apply changes to whatever k8s context you happen to be in, regardless of the `ENV` cmd line var. 
## This PR
* Updates the script to connect to the appropriate k8s cluster depending on the env var

## Checklist
- [x] Documentation has been updated as needed.
