### PR TITLE
Reenable e2e tests

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -41,13 +41,13 @@ jobs:
           java-version: graalvm@20.0.0
       - name: Check Scala formatting
         run: sbt scalafmtCheckAll
-#      - name: Scala Compile
-#        run: sbt Compile/compile Test/compile IntegrationTest/compile
-#      - name: Scala Test
-#        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-#      - name: Run E2E test suite
-#        run: poetry run pytest -v -m e2e
-#        working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
+      - name: Scala Compile
+        run: sbt Compile/compile Test/compile IntegrationTest/compile
+      - name: Scala Test
+        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+      - name: Run E2E test suite
+        run: poetry run pytest -v -m e2e
+        working-directory: ${{ github.workspace }}/orchestration/dagster_orchestration
       - name: Publish Scala coverage
         uses: codecov/codecov-action@v1
       - uses: google-github-actions/setup-gcloud@v0.2.1


### PR DESCRIPTION
## Why

E2E tests were disabled to allow rapid iteration in dev on the dev refresh backfill tooling, which is now underway.

## This PR
* Re-enables the e2e tests in CI


## Checklist
- [ ] Documentation has been updated as needed.
