### PR TITLE
[DSPDC-1814] Add new mode and partitioning scheme for cut snapshot in dev

### DIFF
--- a/orchestration/dagster_orchestration/hca_manage/snapshot.py
+++ b/orchestration/dagster_orchestration/hca_manage/snapshot.py
@@ -17,7 +17,8 @@ from hca_manage.common import data_repo_host, data_repo_profile_ids, DefaultHelp
 
 MAX_SNAPSHOT_DELETE_POLL_SECONDS = 120
 SNAPSHOT_DELETE_POLL_INTERVAL_SECONDS = 2
-SNAPSHOT_NAME_REGEX = r"^hca_(dev|prod|staging)_(\d{4})(\d{2})(\d{2})(_[a-zA-Z][a-zA-Z0-9]{0,13})?_([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})?__(\d{4})(\d{2})(\d{2})(?:_([a-zA-Z][a-zA-Z0-9]{0,13}))?$"
+LEGACY_SNAPSHOT_NAME_REGEX = r"^hca_(dev|prod|staging)_(\d{4})(\d{2})(\d{2})(_[a-zA-Z][a-zA-Z0-9]{0,13})?_([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})?__(\d{4})(\d{2})(\d{2})(?:_([a-zA-Z][a-zA-Z0-9]{0,13}))?$"
+UPDATED_SNAPSHOT_NAME_REGEX = r"^hca_(dev|prod|staging)_([0-9a-f]{32})?__(\d{4})(\d{2})(\d{2})(?:_([a-zA-Z][a-zA-Z0-9]{0,15}))?_(\d{4})(\d{2})(\d{2})(?:_([a-zA-Z][a-zA-Z0-9]{0,15}))?$"
 
 
 class InvalidSnapshotNameException(ValueError):
@@ -192,7 +193,8 @@ class SnapshotManager:
         :param managed_access: Determine which set of readers to grant access to this snapshot (default = False)
         :return: Job ID of the snapshot creation job
         """
-        if not search(SNAPSHOT_NAME_REGEX, snapshot_name):
+        if not search(LEGACY_SNAPSHOT_NAME_REGEX, snapshot_name) \
+                and not search(UPDATED_SNAPSHOT_NAME_REGEX, snapshot_name):
             raise InvalidSnapshotNameException(f"Snapshot name {snapshot_name} is invalid")
 
         reader_list = self.managed_access_reader_list if managed_access else self.publc_access_reader_list

--- a/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/dev_refresh.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/config/dev_refresh/dev_refresh.py
@@ -44,6 +44,30 @@ def run_config_for_per_project_dataset_partition(partition: Partition) -> Dagste
     return run_config
 
 
+def run_config_for_cut_snapshot_partition(partition: Partition) -> DagsterObjectConfigSchema:
+    run_config = {
+        "resources": {
+            "snapshot_config": {
+                "config": {
+                    "source_hca_project_id": partition.value,
+                    "managed_access": "false",
+                }
+            }
+        }
+    }
+
+    return run_config
+
+
+def dev_refresh_cut_snapshot_partition_set() -> PartitionSetDefinition:
+    return PartitionSetDefinition(
+        name="dev_refresh_cut_snapshot_partition_set",
+        pipeline_name="cut_snapshot",
+        partition_fn=get_dev_refresh_partitions,
+        run_config_fn_for_partition=run_config_for_cut_snapshot_partition
+    )
+
+
 def dev_refresh_partition_set() -> PartitionSetDefinition:
     return PartitionSetDefinition(
         name="dev_refresh_partition_set",
@@ -58,5 +82,6 @@ def dev_refresh_per_project_dataset_partition_set() -> PartitionSetDefinition:
         name="per_project_dataset_dev_refresh_partition_set",
         pipeline_name="copy_project_to_new_dataset",
         partition_fn=get_dev_refresh_partitions,
-        run_config_fn_for_partition=run_config_for_per_project_dataset_partition
+        run_config_fn_for_partition=run_config_for_per_project_dataset_partition,
+        mode="dev_refresh"
     )

--- a/orchestration/dagster_orchestration/hca_orchestration/contrib/data_repo/data_repo_service.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/contrib/data_repo/data_repo_service.py
@@ -72,7 +72,8 @@ class DataRepoService:
         dataset_summary: DatasetSummaryModel = result.items[0]
         dataset_manager = DatasetManager(env, self.data_repo_client)
         dataset_model = dataset_manager.retrieve_dataset(dataset_summary.id)
-        return TdrDataset(dataset_name, dataset_model.id, dataset_model.data_project, dataset_model.default_profile_id)
+        return TdrDataset(dataset_model.name, dataset_model.id,
+                          dataset_model.data_project, dataset_model.default_profile_id)
 
     def create_dataset(
             self,

--- a/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -11,11 +11,13 @@ from data_repo_client import SnapshotRequestAccessIncludeModel
 
 from hca_orchestration.config import preconfigure_resource_for_mode
 from hca_orchestration.contrib.slack import key_value_slack_blocks
+from hca_orchestration.resources.data_repo_service import data_repo_service
 from hca_orchestration.solids.create_snapshot import get_completed_snapshot_info, make_snapshot_public, \
     submit_snapshot_job
 from hca_orchestration.solids.data_repo import wait_for_job_completion
 from hca_orchestration.resources.config.dagit import dagit_config
-from hca_orchestration.resources.config.data_repo import hca_manage_config, snapshot_creation_config
+from hca_orchestration.resources.config.data_repo import hca_manage_config, snapshot_creation_config, \
+    dev_refresh_snapshot_creation_config
 
 real_prod_mode = ModeDefinition(
     name="real_prod",
@@ -58,6 +60,23 @@ dev_mode = ModeDefinition(
         "slack": preconfigure_resource_for_mode(live_slack_client, "dev"),
         "snapshot_config": snapshot_creation_config,
         "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev"),
+    }
+)
+
+dev_refresh_mode = ModeDefinition(
+    name="dev_refresh",
+    resource_defs={
+        "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+        "gcs": google_storage_client,
+        "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
+        "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
+        # we don't want to actually hit sam and make a snapshot public
+        # unless we're running in prod
+        "sam_client": noop_sam_client,
+        "slack": preconfigure_resource_for_mode(live_slack_client, "dev"),
+        "snapshot_config": dev_refresh_snapshot_creation_config,
+        "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev"),
+        "data_repo_service": data_repo_service
     }
 )
 
@@ -146,7 +165,7 @@ def message_for_snapshot_done(context: HookContext) -> None:
 
 
 @pipeline(
-    mode_defs=[prod_mode, dev_mode, local_mode, test_mode]
+    mode_defs=[prod_mode, dev_mode, local_mode, test_mode, dev_refresh_mode]
 )
 def cut_snapshot() -> None:
     hooked_submit_snapshot_job = submit_snapshot_job.with_hooks({snapshot_start_notification})

--- a/orchestration/dagster_orchestration/hca_orchestration/repositories.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/repositories.py
@@ -7,7 +7,8 @@ from dagster_utils.resources.data_repo.jade_data_repo import jade_data_repo_clie
 from dagster_utils.resources.google_storage import google_storage_client
 
 from hca_orchestration.config import preconfigure_resource_for_mode
-from hca_orchestration.config.dev_refresh.dev_refresh import dev_refresh_per_project_dataset_partition_set
+from hca_orchestration.config.dev_refresh.dev_refresh import dev_refresh_per_project_dataset_partition_set, \
+    dev_refresh_cut_snapshot_partition_set
 from hca_orchestration.pipelines import copy_project
 from hca_orchestration.pipelines import cut_snapshot, load_hca, validate_egress
 from hca_orchestration.resources import bigquery_service, load_tag
@@ -42,6 +43,7 @@ def all_jobs() -> list[Union[PipelineDefinition, SensorDefinition]]:
         validate_egress,
         build_post_import_sensor(os.environ.get("ENV", "test")),
         copy_project_to_new_dataset_job(),
-        dev_refresh_per_project_dataset_partition_set()
+        dev_refresh_per_project_dataset_partition_set(),
+        dev_refresh_cut_snapshot_partition_set()
     ]
     return defs

--- a/orchestration/dagster_orchestration/hca_orchestration/resources/config/data_repo.py
+++ b/orchestration/dagster_orchestration/hca_orchestration/resources/config/data_repo.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from dagster import resource, String, Bool
 from dagster.core.execution.context.init import InitResourceContext
+
+from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
 
 
 @dataclass
@@ -18,6 +21,28 @@ class SnapshotCreationConfig:
 })
 def snapshot_creation_config(init_context: InitResourceContext) -> SnapshotCreationConfig:
     return SnapshotCreationConfig(**init_context.resource_config)
+
+
+@resource(required_resource_keys={"data_repo_service"},
+          config_schema={
+    "source_hca_project_id": String,
+    "managed_access": Bool
+})
+def dev_refresh_snapshot_creation_config(init_context: InitResourceContext) -> SnapshotCreationConfig:
+    source_hca_project_id = init_context.resource_config["source_hca_project_id"]
+    data_repo_service: DataRepoService = init_context.resources.data_repo_service
+
+    # find the existing dataset, bail out if none are found
+    source_hca_dataset_prefix = f"hca_dev_{source_hca_project_id.replace('-', '')}"
+    result = data_repo_service.find_dataset(source_hca_dataset_prefix, "dev")
+    if not result:
+        raise Exception(f"No dataset for HCA project_id {source_hca_project_id} found")
+
+    # craft a new snapshot name
+    creation_date = datetime.now().strftime("%Y%m%d")
+    snapshot_name = f"{result.dataset_name}_{creation_date}"
+
+    return SnapshotCreationConfig(result.dataset_name, snapshot_name, False)
 
 
 @dataclass


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1814)
We need to cut snapshots for each project ported to dev.

## This PR
* Adds a new mode to the cut snapshot pipeline that will compute the correct source dataset name and snapshot name given a source hca project ID, and an associated partition set over this mode.

## Checklist
- [x] Documentation has been updated as needed.
