### PR TITLE
Sanity check that we have projects and links during dataset validation

### DIFF
--- a/orchestration/hca_manage/check.py
+++ b/orchestration/hca_manage/check.py
@@ -84,12 +84,14 @@ class CheckManager:
                                       project=self.project,
                                       soft_delete_manager=self.soft_delete_manager)
 
+    @property
     def links_count_manager(self) -> CountsManager:
         return CountsManager(dataset=self.dataset,
                              project=self.project,
                              soft_delete_manager=self.soft_delete_manager,
                              entity_type="links")
 
+    @property
     def projects_count_manager(self) -> CountsManager:
         return CountsManager(dataset=self.dataset,
                              project=self.project,
@@ -103,8 +105,8 @@ class CheckManager:
         """
         logging.info("Processing...")
 
-        empty_links_count = self.links_count_manager().check_or_delete_rows()
-        empty_projects_count = self.projects_count_manager().check_or_delete_rows()
+        empty_links_count = self.links_count_manager.check_or_delete_rows()
+        empty_projects_count = self.projects_count_manager.check_or_delete_rows()
         duplicate_count = self.duplicate_manager.check_or_delete_rows()
         null_file_ref_count = self.null_file_ref_manager.check_or_delete_rows()
         dangling_proj_refs_count = self.dangling_file_ref_manager.check_or_delete_rows()
@@ -124,6 +126,9 @@ class CheckManager:
         :return: A named tuple with the counts of rows to soft delete
         """
         logging.info("Processing, deleting as we find anything...")
+
+        empty_links_count = self.links_count_manager.check_or_delete_rows()
+        empty_projects_count = self.projects_count_manager.check_or_delete_rows()
         duplicate_count = self.duplicate_manager.check_or_delete_rows(soft_delete=True)
         null_file_ref_count = self.null_file_ref_manager.check_or_delete_rows(soft_delete=True)
         logging.info("Skipping any rows with dangling project refs, manual intervention required")
@@ -131,7 +136,9 @@ class CheckManager:
         return ProblemCount(
             duplicates=duplicate_count,
             null_file_refs=null_file_ref_count,
-            dangling_project_refs=0
+            dangling_project_refs=0,
+            empty_links_count=empty_links_count,
+            empty_projects_count=empty_projects_count
         )
 
 

--- a/orchestration/hca_manage/common.py
+++ b/orchestration/hca_manage/common.py
@@ -32,9 +32,15 @@ class ProblemCount:
     duplicates: int
     null_file_refs: int
     dangling_project_refs: int
+    empty_links_count: int
+    empty_projects_count: int
 
     def has_problems(self) -> bool:
-        return self.duplicates > 0 or self.null_file_refs > 0 or self.dangling_project_refs > 0
+        return self.duplicates > 0 or \
+            self.null_file_refs > 0 or \
+            self.dangling_project_refs > 0 or \
+            self.empty_links_count > 0 or \
+            self.empty_projects_count > 0
 
 
 def setup_cli_logging_format() -> None:

--- a/orchestration/hca_orchestration/solids/validate_egress.py
+++ b/orchestration/hca_orchestration/solids/validate_egress.py
@@ -40,7 +40,9 @@ def notify_slack_of_egress_validation_results(
             f"Triggering Argo workflow ID: {argo_workflow_id}",
             "Duplicate lines found: " + str(validation_results.duplicates),
             "Null file references found: " + str(validation_results.null_file_refs),
-            "Dangling project references found: " + str(validation_results.dangling_project_refs)
+            "Dangling project references found: " + str(validation_results.dangling_project_refs),
+            "Empty links table: " + str(validation_results.empty_links_count),
+            "Empty projects table: " + str(validation_results.empty_projects_count)
         ]
     else:
         message_lines = [

--- a/orchestration/hca_orchestration/tests/pipelines/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_copy_project.py
@@ -10,8 +10,8 @@ from hca_orchestration.resources.hca_project_config import HcaProjectCopyingConf
 @patch("hca_manage.bq_managers.NullFileRefManager.get_file_table_names", return_value=set())
 @patch("hca_manage.bq_managers.DuplicatesManager.get_rows", return_value=set())
 @patch("hca_manage.bq_managers.DuplicatesManager.get_all_table_names", return_value=set())
-def test_copy_project(mock_all_table_names: Mock, mock_duplicates: Mock, mock_file_table_names: Mock,
-                      mock_null_filerefs: Mock, mock_dangling_proj_refs: Mock) -> None:
+@patch("hca_manage.bq_managers.CountsManager.get_rows", return_value=set())
+def test_copy_project(*mocks) -> None:
     result = copy_project.execute_in_process(
         resources={
             "bigquery_client": MagicMock(),

--- a/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
@@ -56,6 +56,7 @@ class PipelinesTestCase(unittest.TestCase):
     @patch("hca_manage.bq_managers.DuplicatesManager.get_rows")
     @patch("hca_manage.bq_managers.DuplicatesManager.get_all_table_names")
     @patch("hca_manage.bq_managers.DanglingFileRefManager.get_rows")
+    @patch("hca_manage.bq_managers.CountsManager.get_rows")
     def test_validate_egress(self, *mocks):
         """
         currently validate_egress is just a thin wrapper around

--- a/orchestration/hca_orchestration/tests/solids/test_validate_egress.py
+++ b/orchestration/hca_orchestration/tests/solids/test_validate_egress.py
@@ -17,7 +17,8 @@ class PostImportValidateTestCase(unittest.TestCase):
     @patch("hca_manage.bq_managers.NullFileRefManager.get_file_table_names", return_value=set())
     @patch("hca_manage.bq_managers.DuplicatesManager.get_rows", return_value=set())
     @patch("hca_manage.bq_managers.DuplicatesManager.get_all_table_names", return_value=set())
-    def test_post_import_validate(self, mock_all_table_names: Mock, mock_duplicates: Mock, mock_file_table_names: Mock,
+    @patch("hca_manage.bq_managers.CountsManager.get_rows", return_value=set())
+    def test_post_import_validate(self, mock_counts: Mock, mock_all_table_names: Mock, mock_duplicates: Mock, mock_file_table_names: Mock,
                                   mock_null_filerefs: Mock, mock_dangling_proj_refs: Mock):
         """
         Mock bigQuery interactions and make sure the post_import_validate solid works as desired.
@@ -51,6 +52,7 @@ class PostImportValidateTestCase(unittest.TestCase):
         expected_duplicate_issues = len(fake_table_names) * len(fake_duplicate_ids)
         expected_file_ref_issues = len(fake_file_table_names) * len(fake_null_fileref_ids)
         expected_dangling_proj_refs = len(fake_table_names) * len(fake_dangling_proj_refs)
+
         self.assertEqual(expected_duplicate_issues, result.output_value().duplicates)
         self.assertEqual(expected_file_ref_issues, result.output_value().null_file_refs)
         self.assertEqual(expected_dangling_proj_refs, result.output_value().dangling_project_refs)
@@ -83,7 +85,7 @@ class NotifySlackOfEgressValidationResultsTestCase(unittest.TestCase):
                 mode_def=test_mode,
                 input_values={
                     "validation_results": ProblemCount(
-                        duplicates=3, null_file_refs=2, dangling_project_refs=3
+                        duplicates=3, null_file_refs=2, dangling_project_refs=3, empty_projects_count=0, empty_links_count=0
                     )
                 }
             )
@@ -110,7 +112,7 @@ class NotifySlackOfEgressValidationResultsTestCase(unittest.TestCase):
                 mode_def=test_mode,
                 input_values={
                     "validation_results": ProblemCount(
-                        duplicates=0, null_file_refs=0, dangling_project_refs=0
+                        duplicates=0, null_file_refs=0, dangling_project_refs=0, empty_projects_count=0, empty_links_count=0
                     )
                 }
             )


### PR DESCRIPTION
## Why

We should know if a dataset has 0 links or projects, as that indicates a bad or failed project copy.

## This PR
* Adds the needed checks to the dataset validation script

## Checklist
- [ ] Documentation has been updated as needed.
