### PR TITLE
Update tool

### DIFF
--- a/orchestration/hca_manage/billing_profile.py
+++ b/orchestration/hca_manage/billing_profile.py
@@ -23,6 +23,10 @@ def run(arguments: Optional[list[str]] = None) -> None:
     billing_profile_query = subparsers.add_parser("enumerate")
     billing_profile_query.set_defaults(func=_enumerate_billing_profiles)
 
+    billing_profile_retrieve = subparsers.add_parser("retrieve")
+    billing_profile_retrieve.add_argument("-i", "--billing_profile_id", required=True)
+    billing_profile_retrieve.set_defaults(func=_retrieve_billing_profile)
+
     args = parser.parse_args(arguments)
     args.func(args)
 
@@ -52,6 +56,15 @@ def _enumerate_billing_profiles(args: argparse.Namespace) -> None:
     resources_api_client = get_resources_api_client(host)
 
     response = resources_api_client.enumerate_profiles()
+
+    logging.info(response)
+
+
+def _retrieve_billing_profile(args: argparse.Namespace) -> None:
+    host = data_repo_host[args.env]
+    resources_api_client = get_resources_api_client(host)
+
+    response = resources_api_client.retrieve_profile(id=args.billing_profile_id)
 
     logging.info(response)
 

--- a/orchestration/hca_manage/find_project_rows.py
+++ b/orchestration/hca_manage/find_project_rows.py
@@ -41,20 +41,20 @@ def _query_for_project(args: argparse.Namespace) -> None:
 
     bq_service = BigQueryService(Client())
     query = f"""
-    SELECT * FROM `datarepo_{dataset_name}.project`
+    SELECT * FROM `{dataset_name}.project`
     WHERE project_id = '{hca_project_id}'
     """
 
     logging.info("Project row IDs = ")
-    project_row_ids = bq_service.run_query(query, bq_project_id).result()
+    project_row_ids = bq_service.run_query(query, bq_project_id)
     for row in project_row_ids:
         logging.info(row["datarepo_row_id"])
 
     query = f"""
-    SELECT * FROM `datarepo_{dataset_name}.links`
+    SELECT * FROM `{dataset_name}.links`
     WHERE project_id = '{hca_project_id}'
     """
-    links_rows = bq_service.run_query(query, bq_project_id).result()
+    links_rows = bq_service.run_query(query, bq_project_id)
     logging.info("")
     logging.info("Links row IDs = ")
     for row in links_rows:


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1906)
The find project tool is needed when soft deleting projects, but it is broken.

## This PR
* Removes calls to `result()` since the bq service is giving back a row iterator, not a job instance.

## Checklist
- [ ] Documentation has been updated as needed.
