### PR TITLE
Prevent upgrade to 3.9.7

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python 3.9 for dataflow tests
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.9.6
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.8
       - name: Cache dependencies

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.9.6
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.1
       with:

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
 # until https://bugs.python.org/issue45081 is pushed in an upcoming python version we can't upgrade past 3.9.6
-python = "<3.9.7"
+python = "3.9.6"
 argo-workflows = "^5.0.0"
 cached-property = "^1.5.2"
 dagster = "0.12.10"

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -5,7 +5,8 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "~3.9"
+# until https://bugs.python.org/issue45081 is pushed in an upcoming python version we can't upgrade past 3.9.6
+python = "<3.9.7"
 argo-workflows = "^5.0.0"
 cached-property = "^1.5.2"
 dagster = "0.12.10"


### PR DESCRIPTION
## Why

There is a regression in python [3.9.7](https://bugs.python.org/issue45081). I believe a fix has been merged, but until it is released we cannot go past 3.9.6 due to the way our Beam Runner dataclasses subclass a base Protocol.

## This PR
* Adds a dependency specification for python to keep us off 3.9.7

## Checklist
- [ ] Documentation has been updated as needed.
