### PR TITLE
Upgrade python version in dockerfile

### DIFF
--- a/orchestration/Dockerfile
+++ b/orchestration/Dockerfile
@@ -1,7 +1,7 @@
 ## Builds the dagster "user code deployment" image that will
 ## hold our pipelines/solids/etc.
 
-FROM python:3.9.1-slim as base
+FROM python:3.9.6-slim as base
 
 ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Why

We require python 3.9.6 now in our builds, the dockerfile should be kept up to date.
(I would love to have this pull from a shared ENV var so our pyproject.toml and this dockerfile can be 
kept in sync, but sadly poetry does not support ENV vars at the moment).

## This PR
* Bumps the python image to 3.9.6
## Checklist
- [x] Documentation has been updated as needed.
