### PR TITLE
Un-hardcode BQ location

### DIFF
--- a/orchestration/hca_manage/find_project_rows.py
+++ b/orchestration/hca_manage/find_project_rows.py
@@ -29,6 +29,7 @@ def run(arguments: Optional[list[str]] = None) -> None:
     parser.add_argument("-p", "--hca_project_id", required=True)
     parser.add_argument("-d", "--dataset_name", required=True)
     parser.add_argument("-b", "--bq_project_id", required=True)
+    parser.add_argument("-b", "--bq_region", required=True)
 
     args = parser.parse_args(arguments)
     _query_for_project(args)
@@ -38,6 +39,7 @@ def _query_for_project(args: argparse.Namespace) -> None:
     dataset_name = args.dataset_name
     hca_project_id = args.hca_project_id
     bq_project_id = args.bq_project_id
+    bq_region = args.bq_region
 
     bq_service = BigQueryService(Client())
     query = f"""
@@ -46,7 +48,7 @@ def _query_for_project(args: argparse.Namespace) -> None:
     """
 
     logging.info("Project row IDs = ")
-    project_row_ids = bq_service.run_query(query, bq_project_id)
+    project_row_ids = bq_service.run_query(query, bq_project_id, bq_region)
     for row in project_row_ids:
         logging.info(row["datarepo_row_id"])
 
@@ -54,7 +56,7 @@ def _query_for_project(args: argparse.Namespace) -> None:
     SELECT * FROM `{dataset_name}.links`
     WHERE project_id = '{hca_project_id}'
     """
-    links_rows = bq_service.run_query(query, bq_project_id)
+    links_rows = bq_service.run_query(query, bq_project_id, bq_region)
     logging.info("")
     logging.info("Links row IDs = ")
     for row in links_rows:

--- a/orchestration/hca_manage/snapshot.py
+++ b/orchestration/hca_manage/snapshot.py
@@ -201,7 +201,8 @@ class SnapshotManager:
                 "monster-dev@dev.test.firecloud.org",
                 "azul-dev@dev.test.firecloud.org"
             ],
-            "prod": ["hca-snapshot-readers@firecloud.org", "monster@firecloud.org"]
+            "prod": ["hca-snapshot-readers@firecloud.org", "monster@firecloud.org"],
+            "real_prod": []
         }[self.environment]
         self.public_access_reader_list = {
             "dev": [
@@ -210,7 +211,8 @@ class SnapshotManager:
                 "azul-dev@dev.test.firecloud.org",
                 "azul-public-dev@dev.test.firecloud.org"
             ],
-            "prod": ["hca-snapshot-readers@firecloud.org", "monster@firecloud.org"]
+            "prod": ["hca-snapshot-readers@firecloud.org", "monster@firecloud.org"],
+            "real_prod": []
         }[self.environment]
 
     def submit_snapshot_request(

--- a/orchestration/hca_orchestration/contrib/bigquery.py
+++ b/orchestration/hca_orchestration/contrib/bigquery.py
@@ -35,7 +35,7 @@ class BigQueryService:
         query_job = self.bigquery_client.query(
             query,
             job_config,
-            location='US',
+            location='us-central1',
             project=bigquery_project
         )
 
@@ -46,7 +46,7 @@ class BigQueryService:
             query: str,
             bigquery_project: str,
             query_params: list[ArrayQueryParameter] = [],
-            location: str = 'US'
+            location: str = 'us-central1'
     ) -> RowIterator:
         """
         Performs a bigquery query, with no external destination (table or otherwise)
@@ -103,7 +103,7 @@ class BigQueryService:
         query_job = self.bigquery_client.query(
             query,
             job_config,
-            location='US',
+            location='us-central1',
             project=bigquery_project
         )
 

--- a/orchestration/hca_orchestration/contrib/bigquery.py
+++ b/orchestration/hca_orchestration/contrib/bigquery.py
@@ -21,7 +21,8 @@ class BigQueryService:
             self,
             query: str,
             destination_table: str,
-            bigquery_project: str
+            bigquery_project: str,
+            location: str
     ) -> RowIterator:
         """
         Performs a bigquery query, with no external table definitions.
@@ -35,7 +36,7 @@ class BigQueryService:
         query_job = self.bigquery_client.query(
             query,
             job_config,
-            location='us-central1',
+            location=location,
             project=bigquery_project
         )
 
@@ -45,8 +46,8 @@ class BigQueryService:
             self,
             query: str,
             bigquery_project: str,
-            query_params: list[ArrayQueryParameter] = [],
-            location: str = 'us-central1'
+            location: str,
+            query_params: list[ArrayQueryParameter] = []
     ) -> RowIterator:
         """
         Performs a bigquery query, with no external destination (table or otherwise)
@@ -70,7 +71,8 @@ class BigQueryService:
             schema: Optional[list[dict[str, str]]],
             table_name: str,
             destination: str,
-            bigquery_project: str
+            bigquery_project: str,
+            location: str
     ) -> RowIterator:
         """
         Performs a bigquery query using an external table definition, using the supplied
@@ -103,7 +105,7 @@ class BigQueryService:
         query_job = self.bigquery_client.query(
             query,
             job_config,
-            location='us-central1',
+            location=location,
             project=bigquery_project
         )
 

--- a/orchestration/hca_orchestration/contrib/gcs.py
+++ b/orchestration/hca_orchestration/contrib/gcs.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse
+import logging
 
 from dataclasses import dataclass
 from google.cloud.storage.client import Client
@@ -9,6 +10,16 @@ def path_has_any_data(bucket: str, prefix: str, gcs: Client) -> bool:
     blobs = [blob for blob in
              gcs.list_blobs(bucket, prefix=prefix)]
     return any([blob.size > 0 for blob in blobs])
+
+
+def remove_empty_blobs(bucket: str, prefix: str, gcs: Client) -> None:
+    """Checks the given path for any blobs of non-zero size"""
+    blobs = [blob for blob in
+             gcs.list_blobs(bucket, prefix=prefix)]
+    for blob in blobs:
+        if blob.size == 0:
+            logging.info(f"Removing zero byte blob at {blob.name}")
+            blob.delete()
 
 
 @dataclass

--- a/orchestration/hca_orchestration/models/hca_dataset.py
+++ b/orchestration/hca_orchestration/models/hca_dataset.py
@@ -11,6 +11,7 @@ class TdrDataset:
     dataset_id: str
     project_id: str
     billing_profile_id: str
+    bq_location: str
 
     def fully_qualified_jade_dataset_name(self) -> str:
         return f"datarepo_{self.dataset_name}"

--- a/orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/hca_orchestration/pipelines/load_hca.py
@@ -51,7 +51,7 @@ dev_mode = ModeDefinition(
         "target_hca_dataset": target_hca_dataset,
         "bigquery_service": bigquery_service,
         "data_repo_service": data_repo_service,
-        "slack": console_slack_client,  # (live_slack_client, "dev"),
+        "slack": preconfigure_resource_for_mode(live_slack_client, "dev"),
         "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev")
     }
 )

--- a/orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/hca_orchestration/pipelines/load_hca.py
@@ -42,7 +42,7 @@ prod_mode = ModeDefinition(
 dev_mode = ModeDefinition(
     name="dev",
     resource_defs={
-        "beam_runner": preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "dev"),
+        "beam_runner": local_beam_runner,  # preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "dev"),
         "bigquery_client": bigquery_client,
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
         "gcs": google_storage_client,
@@ -52,7 +52,7 @@ dev_mode = ModeDefinition(
         "target_hca_dataset": target_hca_dataset,
         "bigquery_service": bigquery_service,
         "data_repo_service": data_repo_service,
-        "slack": preconfigure_resource_for_mode(live_slack_client, "dev"),
+        "slack": console_slack_client,  # (live_slack_client, "dev"),
         "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev")
     }
 )

--- a/orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/hca_orchestration/pipelines/load_hca.py
@@ -1,5 +1,4 @@
 from dagster import ModeDefinition, pipeline
-from dagster import ResourceDefinition
 from dagster_gcp.gcs import gcs_pickle_io_manager
 from dagster_utils.resources.beam.k8s_beam_runner import k8s_dataflow_beam_runner
 from dagster_utils.resources.beam.local_beam_runner import local_beam_runner
@@ -14,7 +13,7 @@ from hca_orchestration.resources import load_tag, bigquery_service, mock_bigquer
 from hca_orchestration.resources.config.dagit import dagit_config
 from hca_orchestration.resources.config.scratch import scratch_config
 from hca_orchestration.resources.config.target_hca_dataset import target_hca_dataset
-from hca_orchestration.resources.data_repo_service import data_repo_service
+from hca_orchestration.resources.data_repo_service import data_repo_service, mock_data_repo_service
 from hca_orchestration.solids.load_hca.data_files.load_data_files import import_data_files
 from hca_orchestration.solids.load_hca.data_files.load_data_metadata_files import file_metadata_fanout
 from hca_orchestration.solids.load_hca.non_file_metadata.load_non_file_metadata import non_file_metadata_fanout
@@ -86,7 +85,7 @@ test_mode = ModeDefinition(
         "scratch_config": scratch_config,
         "target_hca_dataset": target_hca_dataset,
         "bigquery_service": mock_bigquery_service,
-        "data_repo_service": ResourceDefinition.mock_resource(),
+        "data_repo_service": mock_data_repo_service,
         "slack": console_slack_client,
         "dagit_config": preconfigure_resource_for_mode(dagit_config, "test")
     }

--- a/orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/hca_orchestration/pipelines/load_hca.py
@@ -18,7 +18,7 @@ from hca_orchestration.solids.load_hca.data_files.load_data_files import import_
 from hca_orchestration.solids.load_hca.data_files.load_data_metadata_files import file_metadata_fanout
 from hca_orchestration.solids.load_hca.non_file_metadata.load_non_file_metadata import non_file_metadata_fanout
 from hca_orchestration.solids.load_hca.stage_data import clear_scratch_dir, pre_process_metadata, create_scratch_dataset
-from hca_orchestration.solids.load_hca.utilities import initial_solid, terminal_solid
+from hca_orchestration.solids.load_hca.utilities import initial_solid, validate_and_notify
 
 prod_mode = ModeDefinition(
     name="prod",
@@ -107,4 +107,4 @@ def load_hca() -> None:
     file_metadata_results = file_metadata_fanout(result, staging_dataset).collect()
     non_file_metadata_results = non_file_metadata_fanout(result, staging_dataset).collect()
 
-    terminal_solid(file_metadata_results, non_file_metadata_results)
+    validate_and_notify(file_metadata_results, non_file_metadata_results)

--- a/orchestration/hca_orchestration/pipelines/load_hca.py
+++ b/orchestration/hca_orchestration/pipelines/load_hca.py
@@ -41,7 +41,7 @@ prod_mode = ModeDefinition(
 dev_mode = ModeDefinition(
     name="dev",
     resource_defs={
-        "beam_runner": local_beam_runner,  # preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "dev"),
+        "beam_runner": preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "dev"),
         "bigquery_client": bigquery_client,
         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
         "gcs": google_storage_client,

--- a/orchestration/hca_orchestration/resources/config/target_hca_dataset.py
+++ b/orchestration/hca_orchestration/resources/config/target_hca_dataset.py
@@ -10,14 +10,15 @@ from hca_orchestration.models.hca_dataset import TdrDataset
 from hca_orchestration.resources.hca_project_config import HcaProjectCopyingConfig
 
 
-@resource({
-    "dataset_name": String,
-    "dataset_id": String,
-    "project_id": String,
-    "billing_profile_id": String,
+@resource(required_resource_keys={"data_repo_service"},
+          config_schema={
+    "dataset_id": String
 })
 def target_hca_dataset(init_context: InitResourceContext) -> TdrDataset:
-    return TdrDataset(**init_context.resource_config)
+    data_repo_service: DataRepoService = init_context.resources.data_repo_service
+    target_dataset = data_repo_service.get_dataset(init_context.resource_config["dataset_id"])
+
+    return target_dataset
 
 
 @resource(

--- a/orchestration/hca_orchestration/resources/data_repo_service.py
+++ b/orchestration/hca_orchestration/resources/data_repo_service.py
@@ -1,6 +1,8 @@
 from dagster import resource, InitResourceContext
+from unittest.mock import MagicMock
 
 from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
+from hca_orchestration.models.hca_dataset import TdrDataset
 
 
 @resource(
@@ -8,3 +10,16 @@ from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoServic
 )
 def data_repo_service(init_context: InitResourceContext) -> DataRepoService:
     return DataRepoService(init_context.resources.data_repo_client)
+
+
+@resource
+def mock_data_repo_service(init_context: InitResourceContext) -> DataRepoService:
+    mock_svc = MagicMock()
+    mock_svc.get_dataset = MagicMock(
+        return_value=TdrDataset(
+            "fake_dataset",
+            "fake_dataset_id",
+            "fake_project_id",
+            "fake_billing_profile_id",
+            "fake_bq_location"))
+    return mock_svc

--- a/orchestration/hca_orchestration/resources/hca_project_config.py
+++ b/orchestration/hca_orchestration/resources/hca_project_config.py
@@ -7,16 +7,19 @@ class HcaProjectCopyingConfig:
     source_hca_project_id: str
     source_snapshot_name: str
     source_bigquery_project_id: str
+    source_bigquery_region: str
 
 
 @resource({
     "source_hca_project_id": str,
     "source_snapshot_name": str,
     "source_bigquery_project_id": str,
+    "source_bigquery_region": str
 })
 def hca_project_copying_config(context: InitResourceContext) -> HcaProjectCopyingConfig:
     return HcaProjectCopyingConfig(
         source_hca_project_id=context.resource_config["source_hca_project_id"],
         source_snapshot_name=context.resource_config["source_snapshot_name"],
         source_bigquery_project_id=context.resource_config["source_bigquery_project_id"],
+        source_bigquery_region=context.resource_config["source_bigquery_region"]
     )

--- a/orchestration/hca_orchestration/solids/load_hca/data_files/load_data_files.py
+++ b/orchestration/hca_orchestration/solids/load_hca/data_files/load_data_files.py
@@ -104,7 +104,8 @@ def _determine_files_to_load(
         FILE_LOAD_TABLE_BQ_SCHEMA,
         file_load_table_name,
         f"{staging_dataset}.{file_load_table_name}",
-        scratch_config.scratch_bq_project
+        scratch_config.scratch_bq_project,
+        location=target_hca_dataset.bq_location
     )
     return rows
 

--- a/orchestration/hca_orchestration/solids/load_hca/data_files/load_data_metadata_files.py
+++ b/orchestration/hca_orchestration/solids/load_hca/data_files/load_data_metadata_files.py
@@ -79,7 +79,8 @@ def _inject_file_ids(
         ],
         table_name=file_metadata_type,
         destination=f"{scratch_dataset_name}.{destination_table_name}",
-        bigquery_project=scratch_config.scratch_bq_project
+        bigquery_project=scratch_config.scratch_bq_project,
+        location=target_hca_dataset.bq_location
     )
 
     return rows

--- a/orchestration/hca_orchestration/solids/load_hca/load_table.py
+++ b/orchestration/hca_orchestration/solids/load_hca/load_table.py
@@ -10,7 +10,7 @@ from google.cloud.storage import Client
 
 from hca_orchestration.contrib.bigquery import BigQueryService
 from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
-from hca_orchestration.contrib.gcs import path_has_any_data
+from hca_orchestration.contrib.gcs import path_has_any_data, remove_empty_blobs
 from hca_orchestration.models.hca_dataset import TdrDataset
 from hca_orchestration.models.scratch import ScratchConfig
 from hca_orchestration.support.typing import HcaScratchDatasetName, MetadataType, MetadataTypeFanoutResult
@@ -57,6 +57,8 @@ def load_table(
     if not path_has_any_data(scratch_config.scratch_bucket_name, source_path, gcs_client):
         logging.info(f"No data for metadata type {metadata_type}")
         return None
+
+    remove_empty_blobs(scratch_config.scratch_bucket_name, source_path, gcs_client)
 
     num_new_rows = start_load(
         scratch_config,

--- a/orchestration/hca_orchestration/solids/load_hca/load_table.py
+++ b/orchestration/hca_orchestration/solids/load_hca/load_table.py
@@ -117,7 +117,8 @@ def _diff_hca_table(
         source_paths=source_paths,
         table_name=metadata_type,
         destination=destination,
-        bigquery_project=scratch_config.scratch_bq_project
+        bigquery_project=scratch_config.scratch_bq_project,
+        location=target_hca_dataset.bq_location
     )
 
 
@@ -127,6 +128,7 @@ def _query_rows_to_append(
         scratch_config: ScratchConfig,
         scratch_dataset_name: HcaScratchDatasetName,
         joined_table_name: str,
+        target_hca_dataset: TdrDataset,
         bigquery_service: BigQueryService
 ) -> RowIterator:
     query = f"""
@@ -139,7 +141,8 @@ def _query_rows_to_append(
     return bigquery_service.run_query_with_destination(
         query,
         target_table,
-        scratch_config.scratch_bq_project
+        scratch_config.scratch_bq_project,
+        location=target_hca_dataset.bq_location
     )
 
 
@@ -216,6 +219,7 @@ def start_load(
         scratch_config=scratch_config,
         scratch_dataset_name=scratch_dataset_name,
         joined_table_name=joined_table_name,
+        target_hca_dataset=target_hca_dataset,
         bigquery_service=bigquery_service
     )
 
@@ -267,7 +271,8 @@ def _get_outdated_ids(
 
     bigquery_service.run_query(
         query,
-        bigquery_project=scratch_config.scratch_bq_project
+        bigquery_project=scratch_config.scratch_bq_project,
+        location=target_hca_dataset.bq_location
     )
 
     return out_path

--- a/orchestration/hca_orchestration/solids/load_hca/stage_data.py
+++ b/orchestration/hca_orchestration/solids/load_hca/stage_data.py
@@ -87,6 +87,7 @@ def create_scratch_dataset(context: AbstractComputeExecutionContext) -> HcaScrat
     dataset_name = f"{scratch_bq_project}.{scratch_dataset_prefix}_{load_tag}"
 
     dataset = Dataset(dataset_name)
+    dataset.location = 'us-central1'
     dataset.default_table_expiration_ms = context.resources.scratch_config.scratch_table_expiration_ms
 
     bq_client = context.resources.bigquery_client

--- a/orchestration/hca_orchestration/solids/load_hca/stage_data.py
+++ b/orchestration/hca_orchestration/solids/load_hca/stage_data.py
@@ -6,6 +6,7 @@ from google.cloud.bigquery import Dataset
 from google.cloud.storage.client import Client
 
 from hca_orchestration.support.typing import HcaScratchDatasetName
+from hca_orchestration.models.hca_dataset import TdrDataset
 
 
 @solid(
@@ -71,7 +72,7 @@ def pre_process_metadata(context: AbstractComputeExecutionContext) -> Nothing:
 
 
 @solid(
-    required_resource_keys={"bigquery_client", "load_tag", "scratch_config"},
+    required_resource_keys={"bigquery_client", "load_tag", "scratch_config", "target_hca_dataset"},
     input_defs=[InputDefinition("start", Nothing)],
 )
 def create_scratch_dataset(context: AbstractComputeExecutionContext) -> HcaScratchDatasetName:
@@ -83,11 +84,15 @@ def create_scratch_dataset(context: AbstractComputeExecutionContext) -> HcaScrat
     scratch_bq_project = context.resources.scratch_config.scratch_bq_project
     scratch_dataset_prefix = context.resources.scratch_config.scratch_dataset_prefix
     load_tag = context.resources.load_tag
+    target_hca_dataset: TdrDataset = context.resources.target_hca_dataset
 
     dataset_name = f"{scratch_bq_project}.{scratch_dataset_prefix}_{load_tag}"
 
     dataset = Dataset(dataset_name)
-    dataset.location = 'us-central1'
+
+    # co-locate the staging dataset in the same BQ location as the target TDR dataset
+    # so we can perform joins
+    dataset.location = target_hca_dataset.bq_location
     dataset.default_table_expiration_ms = context.resources.scratch_config.scratch_table_expiration_ms
 
     bq_client = context.resources.bigquery_client

--- a/orchestration/hca_orchestration/solids/load_hca/utilities.py
+++ b/orchestration/hca_orchestration/solids/load_hca/utilities.py
@@ -1,20 +1,33 @@
 from typing import Optional
 
-from dagster import solid
+from dagster import solid, Failure
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 from dagster_utils.contrib.data_repo.typing import JobId
 
+from hca_manage.check import CheckManager
 from hca_orchestration.contrib.slack import key_value_slack_blocks
+from hca_orchestration.models.hca_dataset import TdrDataset
 
 
 @solid(
-    required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config'}
+    required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config', 'data_repo_client'}
 )
 def terminal_solid(
         context: AbstractComputeExecutionContext,
         results1: list[Optional[JobId]],
         results2: list[Optional[JobId]]
 ) -> None:
+    target_hca_dataset: TdrDataset = context.resources.target_hca_dataset
+    check_result = CheckManager(
+        environment="dev",
+        project=target_hca_dataset.project_id,
+        dataset=target_hca_dataset.dataset_name,
+        data_repo_client=context.resources.data_repo_client,
+        snapshot=False
+    ).check_for_all()
+    if check_result.has_problems():
+        raise Failure("Dataset failed validation")
+
     kvs = {
         "Staging area": context.run_config["solids"]["pre_process_metadata"]["config"]["input_prefix"],
         "Target Dataset": context.resources.target_hca_dataset.dataset_name,

--- a/orchestration/hca_orchestration/solids/load_hca/utilities.py
+++ b/orchestration/hca_orchestration/solids/load_hca/utilities.py
@@ -12,7 +12,7 @@ from hca_orchestration.models.hca_dataset import TdrDataset
 @solid(
     required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config', 'data_repo_client'}
 )
-def terminal_solid(
+def validate_and_notify(
         context: AbstractComputeExecutionContext,
         results1: list[Optional[JobId]],
         results2: list[Optional[JobId]]

--- a/orchestration/hca_orchestration/tests/environments/test_load_hca_noop_resources.yaml
+++ b/orchestration/hca_orchestration/tests/environments/test_load_hca_noop_resources.yaml
@@ -11,10 +11,7 @@ resources:
       scratch_table_expiration_ms: 1
   target_hca_dataset:
     config:
-      dataset_name: fake_target_dataset_name
       dataset_id: fake_target_dataset_id
-      project_id: fake_target_jade_project_name
-      billing_profile_id: fake_billing_profile_id
 solids:
   pre_process_metadata:
     config:

--- a/orchestration/hca_orchestration/tests/pipelines/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_copy_project.py
@@ -19,8 +19,8 @@ def test_copy_project(*mocks) -> None:
             "gcs": MagicMock(),
             "scratch_config": MagicMock(),
             "bigquery_service": MagicMock(),
-            "hca_project_copying_config": HcaProjectCopyingConfig("fake_source_project_id", "fake_source_snapshot_name", "fake_bq_project_id"),
-            "target_hca_dataset": TdrDataset("fake_name", "fake_id", "fake_gcp_project_id", "fake_billing_profile_id"),
+            "hca_project_copying_config": HcaProjectCopyingConfig("fake_source_project_id", "fake_source_snapshot_name", "fake_bq_project_id", "fake_region"),
+            "target_hca_dataset": TdrDataset("fake_name", "fake_id", "fake_gcp_project_id", "fake_billing_profile_id", "us-fake-region"),
             "load_tag": MagicMock(),
         })
     assert result.success

--- a/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
@@ -43,7 +43,13 @@ class PipelinesTestCase(unittest.TestCase):
             mode=pipeline_mode
         )
 
-    def test_load_hca_noop_resources(self):
+    @patch("hca_manage.bq_managers.NullFileRefManager.get_rows")
+    @patch("hca_manage.bq_managers.NullFileRefManager.get_file_table_names")
+    @patch("hca_manage.bq_managers.DuplicatesManager.get_rows")
+    @patch("hca_manage.bq_managers.DuplicatesManager.get_all_table_names")
+    @patch("hca_manage.bq_managers.DanglingFileRefManager.get_rows")
+    @patch("hca_manage.bq_managers.CountsManager.get_rows")
+    def test_load_hca_noop_resources(self, *mocks):
         result = self.run_pipeline(load_hca, config_name="test_load_hca_noop_resources.yaml")
 
         self.assertTrue(result.success)

--- a/orchestration/hca_orchestration/tests/solids/load_hca/data_files/test_load_data_files.py
+++ b/orchestration/hca_orchestration/tests/solids/load_hca/data_files/test_load_data_files.py
@@ -23,7 +23,8 @@ load_datafiles_test_mode: ModeDefinition = ModeDefinition(
                 "fake_dataset_name",
                 "1234abc",
                 "fake_hca_project_id",
-                "fake_billing_profile_id"
+                "fake_billing_profile_id",
+                "us-fake-region"
             )),
         "scratch_config": ResourceDefinition.hardcoded_resource(
             ScratchConfig(

--- a/orchestration/hca_orchestration/tests/solids/load_hca/data_files/test_load_data_metadata_files.py
+++ b/orchestration/hca_orchestration/tests/solids/load_hca/data_files/test_load_data_metadata_files.py
@@ -24,10 +24,7 @@ run_config = {
         },
         "target_hca_dataset": {
             "config": {
-                "dataset_name": "dataset_name",
-                "dataset_id": "dataset_id",
-                "project_id": "project_id",
-                "billing_profile_id": "billing_profile_id"
+                "dataset_id": "dataset_id"
             }
         }
     }

--- a/orchestration/hca_orchestration/tests/solids/load_hca/non_file_metadata/test_load_non_file_metadata.py
+++ b/orchestration/hca_orchestration/tests/solids/load_hca/non_file_metadata/test_load_non_file_metadata.py
@@ -23,10 +23,7 @@ run_config = {
         },
         "target_hca_dataset": {
             "config": {
-                "dataset_name": "dataset_name",
                 "dataset_id": "dataset_id",
-                "project_id": "project_id",
-                "billing_profile_id": "billing_profile_id"
             }
         }
     }

--- a/orchestration/hca_orchestration/tests/solids/load_hca/test_load_table.py
+++ b/orchestration/hca_orchestration/tests/solids/load_hca/test_load_table.py
@@ -40,10 +40,7 @@ def run_config(test_bucket_name):
             },
             "target_hca_dataset": {
                 "config": {
-                    "dataset_name": "dataset_name",
-                    "dataset_id": "dataset_id",
-                    "project_id": "project_id",
-                    "billing_profile_id": "billing_profile_id"
+                    "dataset_id": "dataset_id"
                 }
             }
         }
@@ -122,7 +119,8 @@ def test_clear_outdated(data_repo_service):
         "fake_target_dataset_name",
         "1234abc",
         "fake_target_bq_project_id",
-        "fake_billing_profile_id"
+        "fake_billing_profile_id",
+        "fake_location"
     )
 
     gcs = Mock(spec=Client)

--- a/orchestration/hca_orchestration/tests/solids/load_hca/test_stage_data.py
+++ b/orchestration/hca_orchestration/tests/solids/load_hca/test_stage_data.py
@@ -102,6 +102,11 @@ def test_create_scratch_dataset():
                         "append_run_id": False,
                         "load_tag_prefix": "load_tag_prefix"
                     }
+                },
+                "target_hca_dataset": {
+                    "config": {
+                        "dataset_id": "123abc"
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1917)
We have datasets in dev that are not always in the US multi-region. We should be able to import to dataset's in any region needed.

## This PR
* Un-hardcodes the `US` multi-region
* Determines the region of the target dataset at runtime and uses that to a) determine where to create the "staging" dataset and b) thread through the location to downstream import queries
* The staging bucket must _also_ be located in the same region. For now, I've created a staging bucket in "us-central1" that we can use. We'll need to determine if there's a better approach than a staging bucket per region.

## Checklist
- [x] Documentation has been updated as needed.


