### PR TITLE
Update release config

### DIFF
--- a/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
+++ b/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
@@ -9,7 +9,7 @@ from google.cloud.storage.client import Client
 from hca_orchestration.contrib.dagster import gs_csv_partition_reader
 
 
-def load_dcp_release_manifests(mode: str) -> list[PartitionSetDefinition]:
+def load_dcp_release_manifests() -> list[PartitionSetDefinition]:
     """
     Returns a list of PartitionSetDefinitions for all DCP release manifests located at DCP_RELEASE_MANIFEST_PATH.
     DCP_RELEASE_MANIFEST_PATH must be a Google Cloud Storage path. Release manifests must named in the following
@@ -31,15 +31,15 @@ def load_dcp_release_manifests(mode: str) -> list[PartitionSetDefinition]:
         release_manifest_path,
         "load_hca",
         client,
-        mode,
+        "prod",
         run_config_for_dcp_release_partition)
 
     return partition_sets
 
 
-def run_config_for_dcp_release_partition(partition: Partition, mode: str) -> DagsterObjectConfigSchema:
+def run_config_for_dcp_release_partition(partition: Partition) -> DagsterObjectConfigSchema:
     path = file_relative_path(
-        __file__, os.path.join(f"./run_config/{mode}", "dcp_release.yaml")
+        __file__, os.path.join(f"./run_config/prod", "dcp_release.yaml")
     )
 
     run_config: DagsterObjectConfigSchema = load_yaml_from_path(path)

--- a/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
+++ b/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
@@ -11,7 +11,7 @@ from hca_orchestration.contrib.dagster import gs_csv_partition_reader
 
 def load_dcp_release_manifests() -> list[PartitionSetDefinition]:
     """
-    Returns a list of PartitionSetDefinitions for all DCP release manifests located at DCP_RELEASE_MANIFEST_PATH.
+    Returns a list of PartitionSetDefinitions for all DCP release manifests located in PARTITIONS_BUCKET/load_hca.
     DCP_RELEASE_MANIFEST_PATH must be a Google Cloud Storage path. Release manifests must named in the following
     format:
 

--- a/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
+++ b/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
@@ -37,9 +37,9 @@ def load_dcp_release_manifests(mode: str) -> list[PartitionSetDefinition]:
     return partition_sets
 
 
-def run_config_for_dcp_release_partition(partition: Partition) -> DagsterObjectConfigSchema:
+def run_config_for_dcp_release_partition(partition: Partition, mode: str) -> DagsterObjectConfigSchema:
     path = file_relative_path(
-        __file__, os.path.join("./run_config", "dcp_release.yaml")
+        __file__, os.path.join(f"./run_config/{mode}", "dcp_release.yaml")
     )
 
     run_config: DagsterObjectConfigSchema = load_yaml_from_path(path)

--- a/orchestration/hca_orchestration/config/dcp_release/run_config/prod/dcp_release.yaml
+++ b/orchestration/hca_orchestration/config/dcp_release/run_config/prod/dcp_release.yaml
@@ -4,7 +4,7 @@ resources:
       append_run_id: true
   scratch_config:
     config:
-      scratch_bq_project: broad-dsp-monster-hca-prod
+      scratch_bq_project: mystical-slate-284720
       scratch_bucket_name: broad-dsp-monster-hca-prod-staging-storage
       scratch_table_expiration_ms: 86400000
   target_hca_dataset:

--- a/orchestration/hca_orchestration/config/dcp_release/run_config/prod/dcp_release.yaml
+++ b/orchestration/hca_orchestration/config/dcp_release/run_config/prod/dcp_release.yaml
@@ -4,15 +4,12 @@ resources:
       append_run_id: true
   scratch_config:
     config:
-      scratch_bq_project: broad-dsp-monster-hca-dev
-      scratch_bucket_name: broad-dsp-monster-hca-dev-staging-storage
+      scratch_bq_project: broad-dsp-monster-hca-prod
+      scratch_bucket_name: broad-dsp-monster-hca-prod-staging-storage
       scratch_table_expiration_ms: 86400000
   target_hca_dataset:
     config:
-      billing_profile_id: db61c343-6dfe-4d14-84e9-60ddf97ea73f
       dataset_id: d30e68f8-c826-4639-88f3-ae35f00d4185
-      dataset_name: hca_prod_20201120_dcp2
-      project_id: broad-datarepo-terra-prod-hca2
 solids:
   pre_process_metadata:
     config:

--- a/orchestration/hca_orchestration/repositories/base_repositories.py
+++ b/orchestration/hca_orchestration/repositories/base_repositories.py
@@ -44,7 +44,7 @@ def copy_project_to_new_dataset_job() -> PipelineDefinition:
         })
 
 
-def base_jobs(mode: str) -> list[Union[PipelineDefinition, SensorDefinition]]:
+def base_jobs() -> list[Union[PipelineDefinition, SensorDefinition]]:
     defs = [
         cut_snapshot,
         load_hca,
@@ -52,4 +52,4 @@ def base_jobs(mode: str) -> list[Union[PipelineDefinition, SensorDefinition]]:
         validate_ingress_job()
     ]
 
-    return defs + load_dcp_release_manifests(mode)
+    return defs

--- a/orchestration/hca_orchestration/repositories/dev_repositories.py
+++ b/orchestration/hca_orchestration/repositories/dev_repositories.py
@@ -20,7 +20,7 @@ def validate_ingress_job() -> PipelineDefinition:
 
 @repository
 def all_jobs() -> list[PipelineDefinition]:
-    jobs = base_jobs("dev")
+    jobs = base_jobs()
 
     jobs += copy_project_to_new_dataset_partitions()
     jobs += dev_refresh_cut_snapshot_partition_set()

--- a/orchestration/hca_orchestration/repositories/prod_repositories.py
+++ b/orchestration/hca_orchestration/repositories/prod_repositories.py
@@ -1,8 +1,11 @@
 from dagster import PipelineDefinition, repository
 
+from hca_orchestration.config.dcp_release.dcp_release import load_dcp_release_manifests
 from hca_orchestration.repositories.base_repositories import base_jobs
 
 
 @repository
 def all_jobs() -> list[PipelineDefinition]:
-    return base_jobs("prod")
+    jobs = base_jobs()
+    jobs += load_dcp_release_manifests("prod")
+    return jobs

--- a/orchestration/hca_orchestration/repositories/prod_repositories.py
+++ b/orchestration/hca_orchestration/repositories/prod_repositories.py
@@ -7,5 +7,5 @@ from hca_orchestration.repositories.base_repositories import base_jobs
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = base_jobs()
-    jobs += load_dcp_release_manifests("prod")
+    jobs += load_dcp_release_manifests()
     return jobs

--- a/orchestration/hca_orchestration/solids/load_hca/utilities.py
+++ b/orchestration/hca_orchestration/solids/load_hca/utilities.py
@@ -13,7 +13,7 @@ from hca_orchestration.solids.validate_egress import construct_validation_messag
 @solid(
     required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config', 'data_repo_client'}
 )
-def validate_and_notify(
+def validate_and_send_finish_notification(
         context: AbstractComputeExecutionContext,
         results1: list[Optional[JobId]],
         results2: list[Optional[JobId]]
@@ -48,7 +48,7 @@ def validate_and_notify(
 @solid(
     required_resource_keys={'slack', 'target_hca_dataset', 'dagit_config'}
 )
-def initial_solid(context: AbstractComputeExecutionContext) -> None:
+def send_start_notification(context: AbstractComputeExecutionContext) -> None:
     kvs = {
         "Staging area": context.run_config["solids"]["pre_process_metadata"]["config"]["input_prefix"],
         "Target Dataset": context.resources.target_hca_dataset.dataset_name,


### PR DESCRIPTION
## Why

The dcp release partition set was attempting to be parameterized by "mode" + partition; however dagster only passes a partition to the provided run config function, which won't work since we need to know which config file to load depending on the mode. So, given that the dcp releases are really only taking place in prod, I am punting for now and limiting the dcp release partition set to prod mode and hardcoding.

## This PR
* Hardcodes the mode for the dcp release partition set function to prod
* Adds some comments + renames a few methods