### PR TITLE
Validate input_prefix

### DIFF
--- a/orchestration/hca_orchestration/tests/environments/test_load_hca_noop_resources.yaml
+++ b/orchestration/hca_orchestration/tests/environments/test_load_hca_noop_resources.yaml
@@ -15,4 +15,4 @@ resources:
 solids:
   pre_process_metadata:
     config:
-      input_prefix: example_input_prefix
+      input_prefix: gs://fake/example

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -389,6 +389,7 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         case (_, descriptor) =>
           generateFileIngestRequest(descriptor, inputPrefix)
       }.distinctByKey.values
+      fileIngestRequests.debug()
 
       StorageIO.writeJsonListsGeneric(
         fileIngestRequests,

--- a/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/hca/HcaPipelineBuilder.scala
@@ -389,7 +389,6 @@ object HcaPipelineBuilder extends PipelineBuilder[Args] {
         case (_, descriptor) =>
           generateFileIngestRequest(descriptor, inputPrefix)
       }.distinctByKey.values
-      fileIngestRequests.debug()
 
       StorageIO.writeJsonListsGeneric(
         fileIngestRequests,


### PR DESCRIPTION
## Why

A bad input prefix will silently pass through dataflow and is difficult to debug downstream. We should fail the pipeline early when we encounter one.

## This PR
* Adds checks for `gs://` and no trailing slash, related tests.