### PR TITLE
Account for new target path approach

### DIFF
--- a/orchestration/hca_manage/verify_release_manifest.py
+++ b/orchestration/hca_manage/verify_release_manifest.py
@@ -65,7 +65,7 @@ def get_staging_area_file_descriptors(storage_client: Client, staging_areas: set
 
 
 def target_path_from_descriptor(descriptor: dict[str, str]) -> str:
-    return f"/{descriptor['file_id']}/{descriptor['file_name']}"
+    return f"/{descriptor['file_id']}/{descriptor['crc32c']}/{descriptor['file_name']}"
 
 
 def find_files_in_load_history(bq_project: str, dataset: str,


### PR DESCRIPTION
## Why

Data file target paths now include crc32c, the release verification tool should reflect that.

## This PR
* Adds crc32c to the target path 

## Checklist
- [ x ] Documentation has been updated as needed.
