### PR TITLE
Remove test resources from HCA

### DIFF
--- a/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
@@ -7,9 +7,9 @@ from dagster import file_relative_path, ResourceDefinition, Failure, JobDefiniti
 from dagster.core.execution.execution_results import InProcessGraphResult
 from dagster.utils import load_yaml_from_globs
 from dagster.utils.merger import deep_merge_dicts
-from dagster_utils.resources.data_repo.jade_data_repo import noop_data_repo_client
-from dagster_utils.resources.sam import noop_sam_client
+from dagster_utils.resources.sam import Sam
 from dagster_utils.resources.slack import console_slack_client
+from data_repo_client import RepositoryApi
 
 import hca_orchestration.resources.data_repo_service
 from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
@@ -123,14 +123,19 @@ def test_validate_ingress_failure():
             })
 
 
-@patch('dagster_utils.resources.data_repo.jade_data_repo.NoopDataRepoClient.add_snapshot_policy_member')
 def test_cut_snapshot(*mocks):
+    data_repo = MagicMock(spec=RepositoryApi)
+    data_repo.retrieve_job_result = MagicMock(
+        return_value={
+            "id": "fake_object_id",
+            "name": "fake_object_name",
+            "failedFiles": 0})
     job = cut_snapshot.to_job(
         resource_defs={
-            "data_repo_client": noop_data_repo_client,
+            "data_repo_client": ResourceDefinition.hardcoded_resource(data_repo),
             "data_repo_service": ResourceDefinition.hardcoded_resource(Mock(spec=DataRepoService)),
             "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "test"),
-            "sam_client": noop_sam_client,
+            "sam_client": ResourceDefinition.hardcoded_resource(Mock(spec=Sam)),
             "slack": console_slack_client,
             "snapshot_config": snapshot_creation_config,
             "dagit_config": preconfigure_resource_for_mode(dagit_config, "test"),

--- a/orchestration/hca_orchestration/tests/solids/load_hca/data_files/test_load_data_files.py
+++ b/orchestration/hca_orchestration/tests/solids/load_hca/data_files/test_load_data_files.py
@@ -1,9 +1,7 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 
-from dagster import execute_solid, ModeDefinition, SolidExecutionResult, ResourceDefinition
+from dagster import execute_solid, ModeDefinition, SolidExecutionResult, ResourceDefinition, resource
 
-from dagster_utils.resources.bigquery import noop_bigquery_client
-from dagster_utils.resources.google_storage import mock_storage_client
 from data_repo_client.api import RepositoryApi
 from data_repo_client.models import JobModel
 from hca_orchestration.models.hca_dataset import TdrDataset
@@ -11,12 +9,33 @@ from hca_orchestration.resources.config.scratch import ScratchConfig
 from hca_orchestration.solids.load_hca.data_files.load_data_files import diff_file_loads, run_bulk_file_ingest
 from hca_orchestration.support.typing import HcaScratchDatasetName
 
+from google.cloud.storage import Client, Blob
+
+
+@resource
+def _gcs(_init_context) -> Client:
+    gcs = MagicMock(spec=Client)
+    gcs.list_blobs = MagicMock(
+        return_value=[
+            Blob(name='fake_blob_0', bucket='fake_bucket'),
+            Blob(name='fake_blob_1', bucket='fake_bucket'),
+            Blob(name='fake_blob_2', bucket='fake_bucket'),
+            Blob(name='fake_blob_3', bucket='fake_bucket'),
+            Blob(name='fake_blob_4', bucket='fake_bucket'),
+            Blob(name='fake_blob_5', bucket='fake_bucket'),
+            Blob(name='fake_blob_6', bucket='fake_bucket'),
+            Blob(name='fake_blob_7', bucket='fake_bucket'),
+            Blob(name='fake_blob_8', bucket='fake_bucket'),
+            Blob(name='fake_blob_9', bucket='fake_bucket')]
+    )
+    return gcs
+
 
 load_datafiles_test_mode: ModeDefinition = ModeDefinition(
     name="test",
     resource_defs={
-        "gcs": mock_storage_client,
-        "bigquery_client": noop_bigquery_client,
+        "gcs": _gcs,
+        "bigquery_client": ResourceDefinition.mock_resource(),
         "bigquery_service": ResourceDefinition.mock_resource(),
         "target_hca_dataset": ResourceDefinition.hardcoded_resource(
             TdrDataset(

--- a/orchestration/hca_orchestration/tests/solids/test_data_repo.py
+++ b/orchestration/hca_orchestration/tests/solids/test_data_repo.py
@@ -20,12 +20,15 @@ def mock_job_status(completed: bool, successful: bool = True) -> Mock:
     return fake_job_status
 
 
+data_repo = Mock(spec=RepositoryApi)
+
+
 class WaitForJobCompletionTestCase(unittest.TestCase):
     def setUp(self):
         self.test_mode = ModeDefinition(
             name="test",
             resource_defs={
-                "data_repo_client": ResourceDefinition.hardcoded_resource(RepositoryApi),
+                "data_repo_client": ResourceDefinition.hardcoded_resource(data_repo)
             }
         )
 
@@ -46,17 +49,18 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
             mock_job_status(True)
         ]
 
-        with patch('data_repo_client.RepositoryApi.retrieve_job',
-                   side_effect=job_status_sequence) as mocked_retrieve_job:
-            result = execute_solid(
-                base_wait_for_job_completion,
-                run_config=solid_config,
-                mode_def=self.test_mode,
-                input_values={
-                    'job_id': JobId('steve-was-here'),
-                })
-            self.assertTrue(result.success)
-            self.assertEqual(mocked_retrieve_job.call_count, 3)
+        data_repo.retrieve_job = Mock(side_effect=job_status_sequence)
+        self.test_mode.resource_defs["data_repo_client"] = ResourceDefinition.hardcoded_resource(data_repo)
+
+        result = execute_solid(
+            base_wait_for_job_completion,
+            run_config=solid_config,
+            mode_def=self.test_mode,
+            input_values={
+                'job_id': JobId('steve-was-here'),
+            })
+        self.assertTrue(result.success)
+        self.assertEqual(data_repo.retrieve_job.call_count, 3)
 
     def test_fails_if_job_failed(self):
         solid_config = {
@@ -70,18 +74,17 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
             }
         }
 
-        with patch('data_repo_client.RepositoryApi.retrieve_job',
-                   return_value=mock_job_status(completed=True, successful=False)) as mocked_retrieve_job:
-            with self.assertRaisesRegex(Failure, "Job did not complete successfully."):
-                result = execute_solid(
-                    base_wait_for_job_completion,
-                    run_config=solid_config,
-                    mode_def=self.test_mode,
-                    input_values={
-                        'job_id': JobId('steve-was-here'),
-                    })
-                self.assertTrue(result.success)
-                self.assertEqual(mocked_retrieve_job.call_count, 3)
+        data_repo.retrieve_job = Mock(return_value=mock_job_status(completed=True, successful=False))
+        self.test_mode.resource_defs["data_repo_client"] = ResourceDefinition.hardcoded_resource(data_repo)
+
+        with self.assertRaisesRegex(Failure, "Job did not complete successfully."):
+            result = execute_solid(
+                base_wait_for_job_completion,
+                run_config=solid_config,
+                mode_def=self.test_mode,
+                input_values={
+                    'job_id': JobId('steve-was-here'),
+                })
 
     def test_fails_if_max_time_exceeded(self):
         solid_config = {
@@ -95,13 +98,14 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
             }
         }
 
-        with patch('data_repo_client.RepositoryApi.retrieve_job',
-                   return_value=mock_job_status(False)):
-            with self.assertRaisesRegex(Failure, "Exceeded max wait time"):
-                execute_solid(
-                    base_wait_for_job_completion,
-                    run_config=solid_config,
-                    mode_def=self.test_mode,
-                    input_values={
-                        'job_id': JobId('steve-was-here'),
-                    })
+        data_repo.retrieve_job = Mock(return_value=mock_job_status(False))
+        self.test_mode.resource_defs["data_repo_client"] = ResourceDefinition.hardcoded_resource(data_repo)
+
+        with self.assertRaisesRegex(Failure, "Exceeded max wait time"):
+            execute_solid(
+                base_wait_for_job_completion,
+                run_config=solid_config,
+                mode_def=self.test_mode,
+                input_values={
+                    'job_id': JobId('steve-was-here'),
+                })

--- a/orchestration/hca_orchestration/tests/solids/test_data_repo.py
+++ b/orchestration/hca_orchestration/tests/solids/test_data_repo.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from dagster import execute_solid, Failure, ModeDefinition
-from dagster_utils.resources.data_repo.jade_data_repo import noop_data_repo_client
+from dagster import execute_solid, Failure, ModeDefinition, ResourceDefinition
+from data_repo_client import RepositoryApi
 
 from hca_manage.common import JobId
 from hca_orchestration.solids.data_repo import base_wait_for_job_completion
@@ -25,7 +25,7 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
         self.test_mode = ModeDefinition(
             name="test",
             resource_defs={
-                "data_repo_client": noop_data_repo_client,
+                "data_repo_client": ResourceDefinition.hardcoded_resource(RepositoryApi),
             }
         )
 
@@ -46,7 +46,7 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
             mock_job_status(True)
         ]
 
-        with patch('dagster_utils.resources.data_repo.jade_data_repo.NoopDataRepoClient.retrieve_job',
+        with patch('data_repo_client.RepositoryApi.retrieve_job',
                    side_effect=job_status_sequence) as mocked_retrieve_job:
             result = execute_solid(
                 base_wait_for_job_completion,
@@ -70,7 +70,7 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
             }
         }
 
-        with patch('dagster_utils.resources.data_repo.jade_data_repo.NoopDataRepoClient.retrieve_job',
+        with patch('data_repo_client.RepositoryApi.retrieve_job',
                    return_value=mock_job_status(completed=True, successful=False)) as mocked_retrieve_job:
             with self.assertRaisesRegex(Failure, "Job did not complete successfully."):
                 result = execute_solid(
@@ -95,7 +95,7 @@ class WaitForJobCompletionTestCase(unittest.TestCase):
             }
         }
 
-        with patch('dagster_utils.resources.data_repo.jade_data_repo.NoopDataRepoClient.retrieve_job',
+        with patch('data_repo_client.RepositoryApi.retrieve_job',
                    return_value=mock_job_status(False)):
             with self.assertRaisesRegex(Failure, "Exceeded max wait time"):
                 execute_solid(


### PR DESCRIPTION
## Why
We should remove usages of test resources in HCA dagster and replace with mocks either via ResourceDefinition.mock_resource() or ResourceDefinition.hardcoded_resource(<some mock>).
[Relevant ticket](https://broadinstitute.atlassian.net/browse/dspdc-1796)

## This PR
- Removed test resources including the noop_data_repo_client and noop_sam_client.
- Replaced with mocks using hardcoded_resource and supplementing data with patches for the return_values.

## Checklist
- [ ] Documentation has been updated as needed.
