### PR TITLE
Add ability to add a snapshot policy member to all snapshots matching…

### DIFF
--- a/orchestration/hca_orchestration/resources/config/data_repo.py
+++ b/orchestration/hca_orchestration/resources/config/data_repo.py
@@ -22,7 +22,10 @@ class SnapshotCreationConfig:
     'managed_access': Bool
 })
 def snapshot_creation_config(init_context: InitResourceContext) -> SnapshotCreationConfig:
-    dt_suffix = dataset_snapshot_formatted_date(datetime.now())
+    # we use the pipeline start time instead of datetime.now() as this resource may be reconstructed at various
+    # points during the pipeline run and therefore the time may change and lead to differing snapshot names
+    pipeline_start_time = int(init_context.instance.get_run_stats(init_context.pipeline_run.run_id).start_time)
+    dt_suffix = dataset_snapshot_formatted_date(datetime.utcfromtimestamp(pipeline_start_time))
     snapshot_name = f"{init_context.resource_config['dataset_name']}___{dt_suffix}"
 
     qualifier = init_context.resource_config.get('qualifier', None)


### PR DESCRIPTION
## Why

We need to add SAs and other groups as readers to many snapshots occasionally, this automates that process.

## This PR
* Add an option to the `snapshot.py` script to bulk add a policy member to snapshots matching a filter string. 

## Checklist
- [ ] Documentation has been updated as needed.
