### PR TITLE
Add manifest tool mode to query staging area ingest status

### DIFF
--- a/orchestration/hca_manage/manifest.py
+++ b/orchestration/hca_manage/manifest.py
@@ -1,6 +1,11 @@
 """
-Parses a csv of staging areas intended for a DCP release and uploads to a
+Utilities for working with a DCP release manifest (the set of staging areas intended for a DCP release)
+
+This utility will:
+* parse a csv of staging areas intended for a DCP release and upload to a
 bucket for bulk ingest by our pipeline.
+* enumerate any loaded manifests
+* check on the ingest status of staging areas in a local manifest file
 """
 
 import argparse
@@ -8,6 +13,8 @@ import csv
 import logging
 import sys
 import warnings
+import requests
+import json
 
 import dagster
 from dagster_graphql import DagsterGraphQLClient, ShutdownRepositoryLocationStatus, DagsterGraphQLClientError
@@ -112,6 +119,53 @@ def reload(args: argparse.Namespace) -> None:
     logging.info("Reload complete (it may take a few minutes before the repository is available again)")
 
 
+def status(args: argparse.Namespace) -> None:
+    paths = []
+    with open(args.csv_path, "r") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            paths.append(row[0])
+
+    for area in paths:
+        # todo Find a more idiomatic way in python to work w/GraphQL
+        qry = f"""
+            query FilteredRunsQuery {{
+              pipelineRunsOrError(
+                filter: {{
+                  statuses: [SUCCESS]
+                  tags: [
+                    {{
+                      key: "dagster/partition"
+                      value: "{area}"
+                    }}
+                  ]
+                }}
+              ) {{
+                __typename
+                ... on PipelineRuns {{
+                  results {{
+                    runId
+                  }}
+                }}
+              }}
+            }}
+            """
+
+        body = {
+            "operationName": "FilteredRunsQuery", "variables": {}, "query": qry
+        }
+        response = requests.post(
+            "http://localhost:8080/graphql",
+            data=json.dumps(body),
+            headers={
+                "content-type": "application/json"})
+        runs = response.json()['data']['pipelineRunsOrError']['results']
+        if not runs:
+            logging.error(f"{area}\t<no successful runs>")
+        else:
+            logging.error(f"{area}\t{runs[0]['runId']}")
+
+
 if __name__ == '__main__':
     setup_cli_logging_format()
     parser = argparse.ArgumentParser()
@@ -130,6 +184,10 @@ if __name__ == '__main__':
 
     reload_subparser = subparsers.add_parser("reload")
     reload_subparser.set_defaults(func=reload)
+
+    status_subparser = subparsers.add_parser("status")
+    status_subparser.add_argument("-c", "--csv_path", help="CSV path", required=True)
+    status_subparser.set_defaults(func=status)
 
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
## Why

It's annoying to have to piece together the status of each staging area from the runs page or slack.

## This PR
* Leverages the dagster graphql api to query for successful ingest runs for each staging area in a given CSV

## Checklist
- [ ] Documentation has been updated as needed.
