### PR TITLE
Use in proc executor when cutting snapshots to avoid snapshot name ch…

### DIFF
--- a/orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -1,6 +1,6 @@
 import warnings
 
-from dagster import HookContext, PipelineDefinition
+from dagster import HookContext, PipelineDefinition, in_process_executor
 from dagster import success_hook, failure_hook, graph, \
     ExperimentalWarning
 from dagster_gcp.gcs import gcs_pickle_io_manager
@@ -55,7 +55,8 @@ def cut_project_snapshot_job(hca_env: str, jade_env: str, steward: str) -> Pipel
                     },
                 }
             }
-        }
+        },
+        executor_def=in_process_executor
     )
 
 
@@ -93,7 +94,8 @@ def legacy_cut_snapshot_job(hca_env: str, steward: str) -> PipelineDefinition:
                     },
                 }
             }
-        }
+        },
+        executor_def=in_process_executor
     )
 
 


### PR DESCRIPTION

## Why

The snapshot name is dynamically determined when instantiating resources during pipeline execution. When the snapshot creation process crosses date boundaries, the snapshot name can change if we are using the multiprocess executor. 

## This PR
* Switches to the in-proc executor to avoid snapshot name changes

## Checklist
- [ ] Documentation has been updated as needed.
