### PR TITLE
E2E testing for copy project pipeline

### DIFF
--- a/orchestration/hca_manage/snapshot.py
+++ b/orchestration/hca_manage/snapshot.py
@@ -273,6 +273,7 @@ class SnapshotManager:
         Submit a snapshot creation request.
         :param snapshot_name: name of snapshot to created
         :param managed_access: Determine which set of readers to grant access to this snapshot (default = False)
+        :param validate_snapshot_name: Validate the submitted snapshot name against the DCP2 specification naming regex
         :return: Job ID of the snapshot creation job
         """
         if validate_snapshot_name:

--- a/orchestration/hca_orchestration/config/resources/jade_data_repo_client/local.yaml
+++ b/orchestration/hca_orchestration/config/resources/jade_data_repo_client/local.yaml
@@ -1,1 +1,0 @@
-api_url: https://jade.datarepo-dev.broadinstitute.org/

--- a/orchestration/hca_orchestration/config/resources/jade_data_repo_client/local.yaml
+++ b/orchestration/hca_orchestration/config/resources/jade_data_repo_client/local.yaml
@@ -1,0 +1,1 @@
+api_url: https://jade.datarepo-dev.broadinstitute.org/

--- a/orchestration/hca_orchestration/pipelines/copy_project.py
+++ b/orchestration/hca_orchestration/pipelines/copy_project.py
@@ -12,15 +12,15 @@ from hca_orchestration.solids.validate_dataset import validate_copied_dataset
 @graph
 def copy_project() -> None:
     validate_copied_dataset(
-        delete_outdated_tabular_data(
-            inject_file_ids(
-                ingest_tabular_data(
-                    ingest_data_files(
-                        hydrate_subgraphs(
-                            clear_scratch_dir()
-                        )
-                    )
-                )
-            )
-        )
+        # delete_outdated_tabular_data(
+        #     inject_file_ids(
+        #         ingest_tabular_data(
+        #             ingest_data_files(
+        #                 hydrate_subgraphs(
+        #                     clear_scratch_dir()
+        #                 )
+        #             )
+        #         )
+        #     )
+        # )
     )

--- a/orchestration/hca_orchestration/pipelines/copy_project.py
+++ b/orchestration/hca_orchestration/pipelines/copy_project.py
@@ -12,15 +12,15 @@ from hca_orchestration.solids.validate_dataset import validate_copied_dataset
 @graph
 def copy_project() -> None:
     validate_copied_dataset(
-        # delete_outdated_tabular_data(
-        #     inject_file_ids(
-        #         ingest_tabular_data(
-        #             ingest_data_files(
-        #                 hydrate_subgraphs(
-        #                     clear_scratch_dir()
-        #                 )
-        #             )
-        #         )
-        #     )
-        # )
+        delete_outdated_tabular_data(
+            inject_file_ids(
+                ingest_tabular_data(
+                    ingest_data_files(
+                        hydrate_subgraphs(
+                            clear_scratch_dir()
+                        )
+                    )
+                )
+            )
+        )
     )

--- a/orchestration/hca_orchestration/repositories/common.py
+++ b/orchestration/hca_orchestration/repositories/common.py
@@ -14,7 +14,7 @@ from hca_orchestration.resources.data_repo_service import data_repo_service
 
 def copy_project_to_new_dataset_job(src_env: str, target_env: str) -> PipelineDefinition:
     return copy_project.to_job(
-        name="copy_project_to_new_dataset",
+        name=f"copy_project_from_{src_env}_to_{target_env}",
         description=f"Copies a project from {src_env} to {target_env}",
         resource_defs={
             "bigquery_client": bigquery_client,

--- a/orchestration/hca_orchestration/repositories/common.py
+++ b/orchestration/hca_orchestration/repositories/common.py
@@ -12,12 +12,13 @@ from hca_orchestration.resources.config.target_hca_dataset import build_new_targ
 from hca_orchestration.resources.data_repo_service import data_repo_service
 
 
-def copy_project_to_new_dataset_job(env: str) -> PipelineDefinition:
+def copy_project_to_new_dataset_job(src_env: str, target_env: str) -> PipelineDefinition:
     return copy_project.to_job(
         name="copy_project_to_new_dataset",
+        description=f"Copies a project from {src_env} to {target_env}",
         resource_defs={
             "bigquery_client": bigquery_client,
-            "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, env),
+            "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, target_env),
             "gcs": google_storage_client,
             "scratch_config": scratch_config,
             "bigquery_service": bigquery_service,

--- a/orchestration/hca_orchestration/repositories/common.py
+++ b/orchestration/hca_orchestration/repositories/common.py
@@ -1,26 +1,23 @@
-from dagster import PipelineDefinition
+from dagster import PipelineDefinition, in_process_executor
 from dagster_utils.resources.bigquery import bigquery_client
 from dagster_utils.resources.data_repo.jade_data_repo import jade_data_repo_client
 from dagster_utils.resources.google_storage import google_storage_client
 
+from hca_orchestration.config import preconfigure_resource_for_mode
 from hca_orchestration.pipelines import copy_project
-
 from hca_orchestration.resources.config.scratch import scratch_config
-
 from hca_orchestration.resources import bigquery_service, load_tag
 from hca_orchestration.resources.hca_project_config import hca_project_copying_config
-
 from hca_orchestration.resources.config.target_hca_dataset import build_new_target_hca_dataset
-
 from hca_orchestration.resources.data_repo_service import data_repo_service
 
 
-def copy_project_to_new_dataset_job() -> PipelineDefinition:
+def copy_project_to_new_dataset_job(env: str) -> PipelineDefinition:
     return copy_project.to_job(
         name="copy_project_to_new_dataset",
         resource_defs={
             "bigquery_client": bigquery_client,
-            "data_repo_client": jade_data_repo_client,
+            "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, env),
             "gcs": google_storage_client,
             "scratch_config": scratch_config,
             "bigquery_service": bigquery_service,
@@ -28,4 +25,6 @@ def copy_project_to_new_dataset_job() -> PipelineDefinition:
             "target_hca_dataset": build_new_target_hca_dataset,
             "load_tag": load_tag,
             "data_repo_service": data_repo_service,
-        })
+        },
+        executor_def=in_process_executor
+    )

--- a/orchestration/hca_orchestration/repositories/dev_repository.py
+++ b/orchestration/hca_orchestration/repositories/dev_repository.py
@@ -63,7 +63,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job("dev", "dev"),
+        copy_project_to_new_dataset_job("prod", "dev"),
         cut_project_snapshot_job("dev", "dev", "monster-dev@dev.test.firecloud.org"),
         legacy_cut_snapshot_job("dev", "monster-dev@dev.test.firecloud.org"),
         load_hca_job(),

--- a/orchestration/hca_orchestration/repositories/dev_repository.py
+++ b/orchestration/hca_orchestration/repositories/dev_repository.py
@@ -63,7 +63,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job("dev"),
+        copy_project_to_new_dataset_job("dev", "dev"),
         cut_project_snapshot_job("dev", "dev", "monster-dev@dev.test.firecloud.org"),
         legacy_cut_snapshot_job("dev", "monster-dev@dev.test.firecloud.org"),
         load_hca_job(),

--- a/orchestration/hca_orchestration/repositories/dev_repository.py
+++ b/orchestration/hca_orchestration/repositories/dev_repository.py
@@ -63,7 +63,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job(),
+        copy_project_to_new_dataset_job("dev"),
         cut_project_snapshot_job("dev", "dev", "monster-dev@dev.test.firecloud.org"),
         legacy_cut_snapshot_job("dev", "monster-dev@dev.test.firecloud.org"),
         load_hca_job(),

--- a/orchestration/hca_orchestration/repositories/local_repository.py
+++ b/orchestration/hca_orchestration/repositories/local_repository.py
@@ -61,7 +61,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job("local"),
+        copy_project_to_new_dataset_job("dev", "dev"),
         cut_project_snapshot_job("dev", "dev", "monster-dev@dev.test.firecloud.org"),
         legacy_cut_snapshot_job("dev", "monster-dev@dev.test.firecloud.org"),
         load_hca_job(),

--- a/orchestration/hca_orchestration/repositories/local_repository.py
+++ b/orchestration/hca_orchestration/repositories/local_repository.py
@@ -61,7 +61,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job(),
+        copy_project_to_new_dataset_job("local"),
         cut_project_snapshot_job("dev", "dev", "monster-dev@dev.test.firecloud.org"),
         legacy_cut_snapshot_job("dev", "monster-dev@dev.test.firecloud.org"),
         load_hca_job(),

--- a/orchestration/hca_orchestration/repositories/prod_repository.py
+++ b/orchestration/hca_orchestration/repositories/prod_repository.py
@@ -63,7 +63,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job("real_prod"),
+        copy_project_to_new_dataset_job("prod", "real_prod"),
         cut_project_snapshot_job("prod", "prod", "monster@firecloud.org"),
         cut_project_snapshot_job("prod", "real_prod", "monster@firecloud.org"),
         legacy_cut_snapshot_job("prod", "monster@firecloud.org"),

--- a/orchestration/hca_orchestration/repositories/prod_repository.py
+++ b/orchestration/hca_orchestration/repositories/prod_repository.py
@@ -63,7 +63,7 @@ def load_hca_job() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        copy_project_to_new_dataset_job(),
+        copy_project_to_new_dataset_job("real_prod"),
         cut_project_snapshot_job("prod", "prod", "monster@firecloud.org"),
         cut_project_snapshot_job("prod", "real_prod", "monster@firecloud.org"),
         legacy_cut_snapshot_job("prod", "monster@firecloud.org"),

--- a/orchestration/hca_orchestration/resources/config/data_repo.py
+++ b/orchestration/hca_orchestration/resources/config/data_repo.py
@@ -26,7 +26,7 @@ def snapshot_creation_config(init_context: InitResourceContext) -> SnapshotCreat
     # points during the pipeline run and therefore the time may change and lead to differing snapshot names
     pipeline_start_time = int(init_context.instance.get_run_stats(init_context.pipeline_run.run_id).start_time)
     dt_suffix = dataset_snapshot_formatted_date(datetime.utcfromtimestamp(pipeline_start_time))
-    snapshot_name = f"{init_context.resource_config['dataset_name']}___{dt_suffix}"
+    snapshot_name = f"{init_context.resource_config['dataset_name']}_{dt_suffix}"
 
     qualifier = init_context.resource_config.get('qualifier', None)
     if qualifier:

--- a/orchestration/hca_orchestration/resources/config/data_repo.py
+++ b/orchestration/hca_orchestration/resources/config/data_repo.py
@@ -52,14 +52,16 @@ def project_snapshot_creation_config(init_context: InitResourceContext) -> Snaps
 
     # find the existing dataset, bail out if none are found
     env = os.environ["ENV"]
-    source_hca_dataset_prefix = f"hca_{env}_{source_hca_project_id.replace('-', '')}"
+    sanitized_hca_project_name = source_hca_project_id.replace('-', '')
+    source_hca_dataset_prefix = f"hca_{env}_{sanitized_hca_project_name}"
     result = data_repo_service.find_dataset(source_hca_dataset_prefix)
     if not result:
         raise Exception(f"No dataset for project_id {source_hca_project_id} found")
 
     # craft a new snapshot name
     creation_date = datetime.now().strftime("%Y%m%d")
-    snapshot_name = f"{result.dataset_name}_{creation_date}"
+    dataset_creation_date = result.dataset_name.split('__')[1].split('_')[0]
+    snapshot_name = f"hca_{env}_{sanitized_hca_project_name}__{dataset_creation_date}_{creation_date}"
     qualifier = init_context.resource_config.get('qualifier', None)
     if qualifier:
         snapshot_name = f"{snapshot_name}_{qualifier}"

--- a/orchestration/hca_orchestration/solids/copy_project/subgraph_hydration.py
+++ b/orchestration/hca_orchestration/solids/copy_project/subgraph_hydration.py
@@ -197,7 +197,7 @@ def fetch_entities(
             """
         else:
             fetch_entities_query = f"""
-            SELECT '/' || JSON_EXTRACT_SCALAR(descriptor, '$.file_id') || '/' || JSON_EXTRACT_SCALAR(descriptor, '$.file_name') as target_path, * EXCEPT (datarepo_row_id)
+            SELECT '/v1/' || JSON_EXTRACT_SCALAR(descriptor, '$.file_id') || '/' || JSON_EXTRACT_SCALAR(descriptor, '$.file_name') as target_path, * EXCEPT (datarepo_row_id)
             FROM `{bigquery_project_id}.{snapshot_name}.{entity_type}` WHERE {entity_type}_id IN
             UNNEST(@entity_ids)
             """

--- a/orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/hca_orchestration/solids/create_snapshot.py
@@ -1,7 +1,7 @@
 from typing import Iterator
 
 from dagster import AssetMaterialization, EventMetadataEntry, Output, OutputDefinition, solid, Failure, Optional, \
-    Noneable, Field
+    Noneable, Field, Permissive
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 from data_repo_client import RepositoryApi, PolicyMemberRequest, PolicyResponse
 
@@ -11,9 +11,7 @@ from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoServic
 
 
 @solid(
-    config_schema={
-        "validate_snapshot_name": Field(bool, default_value=True)
-    },
+    config_schema=Field(Permissive({"validate_snapshot_name": Field(bool, default_value=True, is_required=False)})),
     required_resource_keys={'data_repo_client', 'snapshot_config', 'hca_manage_config', 'data_repo_service'},
 )
 def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
@@ -31,7 +29,7 @@ def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
     ).submit_snapshot_request_with_name(
         context.resources.snapshot_config.snapshot_name,
         context.resources.snapshot_config.managed_access,
-        context.solid_config["validate_snapshot_name"]
+        context.solid_config["validate_snapshot_name"],
     )
 
 

--- a/orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/hca_orchestration/solids/create_snapshot.py
@@ -26,7 +26,7 @@ def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
         data_repo_profile_id=dataset.billing_profile_id
     ).submit_snapshot_request_with_name(
         context.resources.snapshot_config.snapshot_name,
-        context.resources.snapshot_config.managed_access, validate_snapshot_name=False
+        context.resources.snapshot_config.managed_access
     )
 
 

--- a/orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/hca_orchestration/solids/create_snapshot.py
@@ -1,6 +1,7 @@
 from typing import Iterator
 
-from dagster import AssetMaterialization, EventMetadataEntry, Output, OutputDefinition, solid, Failure
+from dagster import AssetMaterialization, EventMetadataEntry, Output, OutputDefinition, solid, Failure, Optional, \
+    Noneable, Field
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 from data_repo_client import RepositoryApi, PolicyMemberRequest, PolicyResponse
 
@@ -10,6 +11,9 @@ from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoServic
 
 
 @solid(
+    config_schema={
+        "validate_snapshot_name": Field(bool, default_value=True)
+    },
     required_resource_keys={'data_repo_client', 'snapshot_config', 'hca_manage_config', 'data_repo_service'},
 )
 def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
@@ -26,7 +30,8 @@ def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
         data_repo_profile_id=dataset.billing_profile_id
     ).submit_snapshot_request_with_name(
         context.resources.snapshot_config.snapshot_name,
-        context.resources.snapshot_config.managed_access
+        context.resources.snapshot_config.managed_access,
+        context.solid_config["validate_snapshot_name"]
     )
 
 

--- a/orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/hca_orchestration/solids/create_snapshot.py
@@ -26,7 +26,7 @@ def submit_snapshot_job(context: AbstractComputeExecutionContext) -> JobId:
         data_repo_profile_id=dataset.billing_profile_id
     ).submit_snapshot_request_with_name(
         context.resources.snapshot_config.snapshot_name,
-        context.resources.snapshot_config.managed_access
+        context.resources.snapshot_config.managed_access, validate_snapshot_name=False
     )
 
 
@@ -40,6 +40,9 @@ def get_completed_snapshot_info(context: AbstractComputeExecutionContext, job_id
     # retrieve_job_result returns a raw dict (since it can return many kinds of data), so we need to make
     # a second call to the snapshot endpoint to get the actual SnapshotModel from it
     snapshot_info_dict = context.resources.data_repo_client.retrieve_job_result(job_id)
+    snapshot_details = context.resources.data_repo_client.retrieve_snapshot(
+        id=snapshot_info_dict['id'], include=["PROFILE,DATA_PROJECT"])
+
     yield AssetMaterialization(
         asset_key=snapshot_info_dict['id'],
         description="Dataset snapshot created in the data repo",
@@ -55,7 +58,12 @@ def get_completed_snapshot_info(context: AbstractComputeExecutionContext, job_id
             EventMetadataEntry.text(snapshot_info_dict['id'], "snapshot_id",
                                     description="Snapshot ID in the data repo"),
             EventMetadataEntry.text(job_id, "job_id", description="Successful data repo job ID"),
-        ]
+        ],
+        tags={
+            "snapshot_id": snapshot_info_dict['id'],
+            "data_project": snapshot_details.data_project,
+            "snapshot_name": snapshot_info_dict['name']
+        }
     )
     yield Output(snapshot_info_dict['id'])
 

--- a/orchestration/hca_orchestration/solids/validate_dataset.py
+++ b/orchestration/hca_orchestration/solids/validate_dataset.py
@@ -19,22 +19,28 @@ from hca_orchestration.resources.hca_project_config import HcaProjectCopyingConf
 def validate_copied_dataset(context: AbstractComputeExecutionContext) -> Iterator[Output]:
     target_hca_dataset: TdrDataset = context.resources.target_hca_dataset
     hca_project_config: HcaProjectCopyingConfig = context.resources.hca_project_copying_config
-
-    result = CheckManager(
-        environment="dev",
-        project=target_hca_dataset.project_id,
-        dataset=target_hca_dataset.dataset_name,
-        data_repo_client=context.resources.data_repo_client,
-        snapshot=False
-    ).check_for_all()
-
-    if result.has_problems():
-        raise Failure(f"Dataset {target_hca_dataset.dataset_name} failed validation")
+    #
+    # result = CheckManager(
+    #     environment="dev",
+    #     project=target_hca_dataset.project_id,
+    #     dataset=target_hca_dataset.dataset_name,
+    #     data_repo_client=context.resources.data_repo_client,
+    #     snapshot=False
+    # ).check_for_all()
+    #
+    # if result.has_problems():
+    #     raise Failure(f"Dataset {target_hca_dataset.dataset_name} failed validation")
 
     yield AssetMaterialization(
         asset_key=AssetKey([hca_project_config.source_hca_project_id, target_hca_dataset.project_id,
                             target_hca_dataset.dataset_name, target_hca_dataset.dataset_id]),
-        partition=f"{hca_project_config.source_hca_project_id}"
+        partition=f"{hca_project_config.source_hca_project_id}",
+        tags={
+            "dataset_id": target_hca_dataset.dataset_id,
+            "project_id": target_hca_dataset.project_id,
+            "dataset_name": target_hca_dataset.dataset_name,
+            "source_hca_project_id": hca_project_config.source_hca_project_id
+        }
     )
 
-    yield Output(result)
+    yield Output(False)

--- a/orchestration/hca_orchestration/solids/validate_dataset.py
+++ b/orchestration/hca_orchestration/solids/validate_dataset.py
@@ -19,17 +19,17 @@ from hca_orchestration.resources.hca_project_config import HcaProjectCopyingConf
 def validate_copied_dataset(context: AbstractComputeExecutionContext) -> Iterator[Output]:
     target_hca_dataset: TdrDataset = context.resources.target_hca_dataset
     hca_project_config: HcaProjectCopyingConfig = context.resources.hca_project_copying_config
-    #
-    # result = CheckManager(
-    #     environment="dev",
-    #     project=target_hca_dataset.project_id,
-    #     dataset=target_hca_dataset.dataset_name,
-    #     data_repo_client=context.resources.data_repo_client,
-    #     snapshot=False
-    # ).check_for_all()
-    #
-    # if result.has_problems():
-    #     raise Failure(f"Dataset {target_hca_dataset.dataset_name} failed validation")
+
+    result = CheckManager(
+        environment="dev",
+        project=target_hca_dataset.project_id,
+        dataset=target_hca_dataset.dataset_name,
+        data_repo_client=context.resources.data_repo_client,
+        snapshot=False
+    ).check_for_all()
+
+    if result.has_problems():
+        raise Failure(f"Dataset {target_hca_dataset.dataset_name} failed validation")
 
     yield AssetMaterialization(
         asset_key=AssetKey([hca_project_config.source_hca_project_id, target_hca_dataset.project_id,
@@ -43,4 +43,4 @@ def validate_copied_dataset(context: AbstractComputeExecutionContext) -> Iterato
         }
     )
 
-    yield Output(False)
+    yield Output(result)

--- a/orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -34,7 +34,7 @@ def tdr_bigquery_client():
 
 @pytest.fixture
 def delete_dataset_on_exit():
-    return False
+    return True
 
 
 @pytest.fixture

--- a/orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -34,7 +34,7 @@ def tdr_bigquery_client():
 
 @pytest.fixture
 def delete_dataset_on_exit():
-    return False
+    return True
 
 
 @pytest.fixture
@@ -43,9 +43,15 @@ def existing_dataset_id():
 
 
 @pytest.fixture
-def dataset_name() -> str:
+def hca_project_id():
+    return "90bf705c-d891-5ce2-aa54-094488b445c6"
+
+
+@pytest.fixture
+def dataset_name(hca_project_id) -> str:
     dt = dataset_snapshot_formatted_date(datetime.now())
-    return f"hca_dev_{str(uuid.uuid4()).replace('-', '').lower()}__{dt}"
+    suffix = uuid.uuid4().hex[:6]
+    return f"hca_dev_{hca_project_id.replace('-', '')}__{dt}_{suffix}"
 
 
 @pytest.fixture

--- a/orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -1,15 +1,13 @@
 import logging
-from datetime import datetime
+import uuid
 from dataclasses import dataclass
 from typing import Iterable
-import uuid
 
 import pytest
 from google.cloud.bigquery.client import Client
 
 from hca_manage.common import data_repo_host, get_api_client, data_repo_profile_ids
 from hca_manage.dataset import DatasetManager
-from hca_orchestration.support.dates import dataset_snapshot_formatted_date
 
 MONSTER_TEST_DATASET_SENTINEL = "MONSTER_TEST_DELETEME"
 
@@ -39,7 +37,7 @@ def delete_dataset_on_exit():
 
 @pytest.fixture
 def existing_dataset_id():
-    return "bf0cfdd9-556e-4dc0-a93e-cab9fc80e140"
+    return None
 
 
 @pytest.fixture
@@ -49,9 +47,7 @@ def hca_project_id():
 
 @pytest.fixture
 def dataset_name(hca_project_id) -> str:
-    dt = dataset_snapshot_formatted_date(datetime.now())
-    suffix = uuid.uuid4().hex[:6]
-    return f"hca_dev_{hca_project_id.replace('-', '')}__{dt}_{suffix}"
+    return f"monster_hca_test_{str(uuid.uuid4()).replace('-', '_')}"
 
 
 @pytest.fixture

--- a/orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -28,7 +28,7 @@ def tdr_bigquery_client():
 
 @pytest.fixture
 def delete_dataset_on_exit():
-    return False
+    return True
 
 
 @pytest.fixture

--- a/orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -34,17 +34,17 @@ def tdr_bigquery_client():
 
 @pytest.fixture
 def delete_dataset_on_exit():
-    return True
+    return False
 
 
 @pytest.fixture
 def existing_dataset_id():
-    return None
+    return "bf0cfdd9-556e-4dc0-a93e-cab9fc80e140"
 
 
 @pytest.fixture
 def hca_project_id():
-    return "90bf705c-d891-5ce2-aa54-094488b445c6"
+    return "f1da0c8a-5153-4d7c-96ef-92ac06677f0d"
 
 
 @pytest.fixture

--- a/orchestration/hca_orchestration/tests/e2e/conftest.py
+++ b/orchestration/hca_orchestration/tests/e2e/conftest.py
@@ -22,13 +22,19 @@ class DatasetInfo:
 
 
 @pytest.fixture
+def data_repo_client():
+    host = data_repo_host["dev"]
+    return get_api_client(host=host)
+
+
+@pytest.fixture
 def tdr_bigquery_client():
     return Client()
 
 
 @pytest.fixture
 def delete_dataset_on_exit():
-    return True
+    return False
 
 
 @pytest.fixture
@@ -43,8 +49,7 @@ def dataset_name() -> str:
 
 
 @pytest.fixture
-def dataset_info(dataset_name, delete_dataset_on_exit, existing_dataset_id) -> Iterable[DatasetInfo]:
-    data_repo_client = get_api_client(data_repo_host["dev"])
+def dataset_info(dataset_name, delete_dataset_on_exit, existing_dataset_id, data_repo_client) -> Iterable[DatasetInfo]:
     dataset_manager = DatasetManager("dev", data_repo_client)
 
     # setup, either create the dataset or re-use the existing one if passed in as a fixture

--- a/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
@@ -83,7 +83,7 @@ def copied_dataset(snapshot, copy_project_config):
             "source_snapshot_name": snapshot.tags['snapshot_name']
         }
     }
-    copy_project_job = copy_project_to_new_dataset_job("dev")
+    copy_project_job = copy_project_to_new_dataset_job("dev", "dev")
     result: PipelineExecutionResult = execute_pipeline(
         copy_project_job,
         run_config=base_copy_project_config

--- a/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
@@ -20,58 +20,70 @@ from hca_orchestration.tests.e2e.conftest import DatasetInfo
 from hca_orchestration.tests.support.bigquery import assert_metadata_loaded, assert_data_loaded
 
 
-@pytest.mark.e2e
-# load_hca_run_config, copy_project_config, dataset_name, tdr_bigquery_client, dataset_info: DatasetInfo):
-def test_copy_project(copy_project_config):
-    # load_job = load_hca_job()
-    # execute_pipeline(
-    #     load_job,
-    #     run_config=load_hca_run_config
-    # )
-    #
-    # snapshot_config = {
-    #     "resources": {
-    #         "snapshot_config": {
-    #             "config": {
-    #                 "dataset_name": dataset_info.dataset_name,
-    #                 "managed_access": False,
-    #                 "qualifier": None
-    #             }
-    #         }
-    #     },
-    #     "solids": {
-    #         "add_steward": {
-    #             "config": {
-    #                 "snapshot_steward": "aherbst@broadinstitute.org"
-    #             }
-    #         }
-    #     }
-    # }
-    # snapshot_job = cut_snapshot.to_job(
-    #     resource_defs={
-    #         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
-    #         "data_repo_service": data_repo_service,
-    #         "gcs": google_storage_client,
-    #         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
-    #         "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
-    #         "sam_client": preconfigure_resource_for_mode(sam_client, "dev"),
-    #         "slack": console_slack_client,
-    #         "snapshot_config": snapshot_creation_config,
-    #         "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev"),
-    #     },
-    #     executor_def=in_process_executor
-    # )
-    #
-    # snapshot_job_result = execute_pipeline(snapshot_job, run_config=snapshot_config)
-    # snapshot_info = snapshot_job_result.result_for_solid("get_completed_snapshot_info").materializations_during_compute[0]
+def _get_data_repo_client():
+    host = data_repo_host["dev"]
+    return get_api_client(host=host)
 
+
+@pytest.fixture
+def snapshot(load_hca_run_config, dataset_info: DatasetInfo):
+    load_job = load_hca_job()
+    execute_pipeline(
+        load_job,
+        run_config=load_hca_run_config
+    )
+
+    snapshot_config = {
+        "resources": {
+            "snapshot_config": {
+                "config": {
+                    "dataset_name": dataset_info.dataset_name,
+                    "managed_access": False,
+                    "qualifier": None
+                }
+            }
+        },
+        "solids": {
+            "add_steward": {
+                "config": {
+                    "snapshot_steward": "monster-dev@dev.test.firecloud.org"
+                }
+            }
+        }
+    }
+    snapshot_job = cut_snapshot.to_job(
+        resource_defs={
+            "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+            "data_repo_service": data_repo_service,
+            "gcs": google_storage_client,
+            "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
+            "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
+            "sam_client": preconfigure_resource_for_mode(sam_client, "dev"),
+            "slack": console_slack_client,
+            "snapshot_config": snapshot_creation_config,
+            "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev"),
+        },
+        executor_def=in_process_executor
+    )
+
+    snapshot_job_result = execute_pipeline(snapshot_job, run_config=snapshot_config)
+    snapshot_info = snapshot_job_result.result_for_solid(
+        "get_completed_snapshot_info").materializations_during_compute[0]
+
+    yield snapshot_info
+
+    _get_data_repo_client().delete_snapshot(id=snapshot_info.tags["snapshot_id"])
+
+
+@pytest.mark.e2e
+def test_copy_project(snapshot, copy_project_config, tdr_bigquery_client, request):
     base_copy_project_config = copy_project_config.copy()
     base_copy_project_config["resources"]["hca_project_copying_config"] = {
         "config": {
-            "source_bigquery_project_id": snapshot_info.tags['data_project'],
+            "source_bigquery_project_id": snapshot.tags['data_project'],
             "source_bigquery_region": "US",
             "source_hca_project_id": "90bf705c-d891-5ce2-aa54-094488b445c6",
-            "source_snapshot_name": snapshot_info.tags['snapshot_name']
+            "source_snapshot_name": snapshot.tags['snapshot_name']
         }
     }
     copy_project_job = copy_project_to_new_dataset_job("dev")
@@ -83,8 +95,10 @@ def test_copy_project(copy_project_config):
     copied_dataset_bq_project = copied_dataset.tags['project_id']
     copied_dataset_name = copied_dataset.tags['dataset_name']
 
-    import pdb
-    pdb.set_trace()
+    def delete_copied_dataset():
+        _get_data_repo_client().delete_dataset(id=copied_dataset.tags["dataset_id"])
+    request.addFinalizer(delete_copied_dataset)
+
     assert_metadata_loaded("links", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
     assert_metadata_loaded("analysis_file", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
     assert_metadata_loaded("analysis_protocol", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)

--- a/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
@@ -1,15 +1,12 @@
-import uuid
-
 import pytest
 from dagster import execute_pipeline, in_process_executor, PipelineExecutionResult
 from dagster_gcp.gcs import gcs_pickle_io_manager
-from dagster_utils.resources.data_repo.jade_data_repo import jade_data_repo_client, build_client
+from dagster_utils.resources.data_repo.jade_data_repo import jade_data_repo_client
 from dagster_utils.resources.google_storage import google_storage_client
 from dagster_utils.resources.sam import sam_client
 from dagster_utils.resources.slack import console_slack_client
 
 from hca_manage.common import data_repo_host, get_api_client
-from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
 from hca_orchestration.config import preconfigure_resource_for_mode
 from hca_orchestration.pipelines.cut_snapshot import cut_snapshot
 from hca_orchestration.repositories.local_repository import load_hca_job, copy_project_to_new_dataset_job
@@ -98,7 +95,7 @@ def copied_dataset(snapshot, copy_project_config):
     _get_data_repo_client().delete_dataset(id=copied_dataset.tags["dataset_id"])
 
 
-# @pytest.mark.e2e
+@pytest.mark.e2e
 def test_copy_project(copied_dataset, tdr_bigquery_client):
     copied_dataset_bq_project = copied_dataset.tags['project_id']
     copied_dataset_name = copied_dataset.tags['dataset_name']

--- a/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
@@ -26,11 +26,11 @@ def snapshot(monkeypatch, hca_project_id, load_hca_run_config,
              dataset_info: DatasetInfo, data_repo_client: RepositoryApi):
     monkeypatch.setenv("ENV", "dev")
 
-    # load_job = load_hca_job()
-    # execute_pipeline(
-    #     load_job,
-    #     run_config=load_hca_run_config
-    # )
+    load_job = load_hca_job()
+    execute_pipeline(
+        load_job,
+        run_config=load_hca_run_config
+    )
 
     snapshot_config = {
         "resources": {

--- a/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
@@ -1,0 +1,108 @@
+import uuid
+
+import pytest
+from dagster import execute_pipeline, in_process_executor, PipelineExecutionResult
+from dagster_gcp.gcs import gcs_pickle_io_manager
+from dagster_utils.resources.data_repo.jade_data_repo import jade_data_repo_client, build_client
+from dagster_utils.resources.google_storage import google_storage_client
+from dagster_utils.resources.sam import sam_client
+from dagster_utils.resources.slack import console_slack_client
+
+from hca_manage.common import data_repo_host, get_api_client
+from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
+from hca_orchestration.config import preconfigure_resource_for_mode
+from hca_orchestration.pipelines.cut_snapshot import cut_snapshot
+from hca_orchestration.repositories.local_repository import load_hca_job, copy_project_to_new_dataset_job
+from hca_orchestration.resources.config.dagit import dagit_config
+from hca_orchestration.resources.config.data_repo import hca_manage_config, snapshot_creation_config
+from hca_orchestration.resources.data_repo_service import data_repo_service
+from hca_orchestration.tests.e2e.conftest import DatasetInfo
+from hca_orchestration.tests.support.bigquery import assert_metadata_loaded, assert_data_loaded
+
+
+@pytest.mark.e2e
+# load_hca_run_config, copy_project_config, dataset_name, tdr_bigquery_client, dataset_info: DatasetInfo):
+def test_copy_project(copy_project_config):
+    # load_job = load_hca_job()
+    # execute_pipeline(
+    #     load_job,
+    #     run_config=load_hca_run_config
+    # )
+    #
+    # snapshot_config = {
+    #     "resources": {
+    #         "snapshot_config": {
+    #             "config": {
+    #                 "dataset_name": dataset_info.dataset_name,
+    #                 "managed_access": False,
+    #                 "qualifier": None
+    #             }
+    #         }
+    #     },
+    #     "solids": {
+    #         "add_steward": {
+    #             "config": {
+    #                 "snapshot_steward": "aherbst@broadinstitute.org"
+    #             }
+    #         }
+    #     }
+    # }
+    # snapshot_job = cut_snapshot.to_job(
+    #     resource_defs={
+    #         "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "dev"),
+    #         "data_repo_service": data_repo_service,
+    #         "gcs": google_storage_client,
+    #         "hca_manage_config": preconfigure_resource_for_mode(hca_manage_config, "dev"),
+    #         "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "dev"),
+    #         "sam_client": preconfigure_resource_for_mode(sam_client, "dev"),
+    #         "slack": console_slack_client,
+    #         "snapshot_config": snapshot_creation_config,
+    #         "dagit_config": preconfigure_resource_for_mode(dagit_config, "dev"),
+    #     },
+    #     executor_def=in_process_executor
+    # )
+    #
+    # snapshot_job_result = execute_pipeline(snapshot_job, run_config=snapshot_config)
+    # snapshot_info = snapshot_job_result.result_for_solid("get_completed_snapshot_info").materializations_during_compute[0]
+
+    base_copy_project_config = copy_project_config.copy()
+    base_copy_project_config["resources"]["hca_project_copying_config"] = {
+        "config": {
+            "source_bigquery_project_id": snapshot_info.tags['data_project'],
+            "source_bigquery_region": "US",
+            "source_hca_project_id": "90bf705c-d891-5ce2-aa54-094488b445c6",
+            "source_snapshot_name": snapshot_info.tags['snapshot_name']
+        }
+    }
+    copy_project_job = copy_project_to_new_dataset_job("dev")
+    result: PipelineExecutionResult = execute_pipeline(
+        copy_project_job,
+        run_config=base_copy_project_config
+    )
+    copied_dataset = result.result_for_solid("validate_copied_dataset").materializations_during_compute[0]
+    copied_dataset_bq_project = copied_dataset.tags['project_id']
+    copied_dataset_name = copied_dataset.tags['dataset_name']
+
+    import pdb
+    pdb.set_trace()
+    assert_metadata_loaded("links", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("analysis_file", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("analysis_protocol", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("cell_suspension", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("collection_protocol", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("donor_organism", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("enrichment_protocol", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded(
+        "library_preparation_protocol",
+        copied_dataset_name,
+        copied_dataset_bq_project,
+        tdr_bigquery_client)
+    assert_metadata_loaded("process", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded("project", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)
+    assert_metadata_loaded(
+        "specimen_from_organism",
+        copied_dataset_name,
+        copied_dataset_bq_project,
+        tdr_bigquery_client)
+
+    assert_data_loaded("analysis_file", copied_dataset_name, copied_dataset_bq_project, tdr_bigquery_client)

--- a/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_copy_project.py
@@ -5,6 +5,7 @@ from dagster_utils.resources.data_repo.jade_data_repo import jade_data_repo_clie
 from dagster_utils.resources.google_storage import google_storage_client
 from dagster_utils.resources.sam import sam_client
 from dagster_utils.resources.slack import console_slack_client
+from data_repo_client import RepositoryApi
 from google.cloud.bigquery import Client
 
 from hca_orchestration.config import preconfigure_resource_for_mode
@@ -19,7 +20,7 @@ from hca_orchestration.tests.support.bigquery import assert_metadata_loaded, ass
 
 
 @pytest.fixture
-def snapshot(load_hca_run_config, dataset_info: DatasetInfo, data_repo_client):
+def snapshot(load_hca_run_config, dataset_info: DatasetInfo, data_repo_client: RepositoryApi):
     load_job = load_hca_job()
     execute_pipeline(
         load_job,
@@ -69,7 +70,7 @@ def snapshot(load_hca_run_config, dataset_info: DatasetInfo, data_repo_client):
 
 
 @pytest.fixture
-def copied_dataset(snapshot, copy_project_config, data_repo_client):
+def copied_dataset(snapshot, copy_project_config, data_repo_client: RepositoryApi):
     base_copy_project_config = copy_project_config.copy()
     base_copy_project_config["resources"]["hca_project_copying_config"] = {
         "config": {
@@ -92,7 +93,7 @@ def copied_dataset(snapshot, copy_project_config, data_repo_client):
 
 
 # @pytest.mark.e2e
-def test_copy_project(copied_dataset, tdr_bigquery_client):
+def test_copy_project(copied_dataset, tdr_bigquery_client: Client):
     copied_dataset_bq_project = copied_dataset.tags['project_id']
     copied_dataset_name = copied_dataset.tags['dataset_name']
 

--- a/orchestration/hca_orchestration/tests/e2e/test_load_hca.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_load_hca.py
@@ -1,8 +1,8 @@
 import pytest
 from dagster import execute_pipeline
-from google.cloud.bigquery.client import Client, QueryJobConfig
 
 from hca_orchestration.repositories.local_repository import load_hca_job
+from hca_orchestration.tests.support.bigquery import assert_metadata_loaded, assert_data_loaded
 
 
 @pytest.mark.e2e
@@ -28,54 +28,3 @@ def test_load_hca(load_hca_run_config, dataset_name, tdr_bigquery_client, datase
     assert_metadata_loaded("specimen_from_organism", dataset_name, bq_project, tdr_bigquery_client)
     assert_metadata_loaded("specimen_from_organism", dataset_name, bq_project, tdr_bigquery_client)
     assert_data_loaded("sequence_file", dataset_name, bq_project, tdr_bigquery_client)
-
-
-def assert_data_loaded(file_type: str, dataset_name: str, bq_project: str, tdr_bigquery_client: Client):
-    files_loaded = _query_files_loaded(
-        file_type,
-        dataset_name,
-        bq_project,
-        tdr_bigquery_client
-    )
-    assert len(files_loaded) > 0, f"Should have loaded {file_type} data files"
-
-
-def assert_metadata_loaded(metadata_type: str, dataset_name: str, bq_project: str, tdr_bigquery_client: Client):
-    data_loaded = _query_metadata_table(
-        metadata_type,
-        dataset_name,
-        bq_project,
-        tdr_bigquery_client
-    )
-
-    assert len(data_loaded) > 0, f"Should have loaded {metadata_type} rows"
-
-
-def _query_metadata_table(metadata_type: str, dataset_name: str, bq_project: str, client: Client):
-    query = f"""
-    SELECT * FROM `datarepo_{dataset_name}.{metadata_type}`
-    """
-    return _exec_query(query, client, bq_project)
-
-
-def _query_files_loaded(file_type: str, dataset_name: str, bq_project: str, client: Client):
-    query = f"""
-    SELECT * FROM `datarepo_{dataset_name}.{file_type}` f
-    INNER JOIN `datarepo_{dataset_name}.datarepo_load_history` dlh
-    ON dlh.file_id = f.file_id
-    """
-    return _exec_query(query, client, bq_project)
-
-
-def _exec_query(query, client, bq_project):
-    job_config = QueryJobConfig()
-    job_config.use_legacy_sql = False
-
-    query_job = client.query(
-        query,
-        job_config,
-        location="US",
-        project=bq_project
-    )
-    result = query_job.result()
-    return [row for row in result]

--- a/orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
+++ b/orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
@@ -1,7 +1,7 @@
 resources:
   snapshot_config:
     config:
-      dataset_name: 'hca_prod_20201120_dcp2'
+      dataset_name: 'hca_dev_1f1a2b806abd4d2185301800b4320a88__20211101'
       managed_access: False
 solids:
   add_steward:

--- a/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
@@ -9,7 +9,7 @@ from dagster.utils import load_yaml_from_globs
 from dagster.utils.merger import deep_merge_dicts
 from dagster_utils.resources.sam import Sam
 from dagster_utils.resources.slack import console_slack_client
-from data_repo_client import RepositoryApi
+from data_repo_client import RepositoryApi, SnapshotModel
 
 from google.cloud.storage import Client
 
@@ -127,6 +127,9 @@ def test_cut_snapshot(*mocks):
             "id": "fake_object_id",
             "name": "fake_object_name",
             "failedFiles": 0})
+    data_repo.retrieve_snapshot = MagicMock(
+        return_value=SnapshotModel(data_project="fake_data_project")
+    )
     job = cut_snapshot.to_job(
         resource_defs={
             "data_repo_client": ResourceDefinition.hardcoded_resource(data_repo),

--- a/orchestration/hca_orchestration/tests/solids/test_create_snapshot.py
+++ b/orchestration/hca_orchestration/tests/solids/test_create_snapshot.py
@@ -36,7 +36,7 @@ def test_submit_snapshot_job_calls_submit_snapshot_job_in_hca_manage():
         )
         assert result.success
         assert result.output_value() == JobId('abcde')
-        submit_snap.assert_called_once_with('fake', False)
+        submit_snap.assert_called_once_with('fake', False, True)
 
 
 def test_make_snapshot_public_hits_correct_sam_path():

--- a/orchestration/hca_orchestration/tests/support/bigquery.py
+++ b/orchestration/hca_orchestration/tests/support/bigquery.py
@@ -1,0 +1,52 @@
+from google.cloud.bigquery import QueryJobConfig, Client
+
+
+def assert_data_loaded(file_type: str, dataset_name: str, bq_project: str, tdr_bigquery_client: Client):
+    files_loaded = _query_files_loaded(
+        file_type,
+        dataset_name,
+        bq_project,
+        tdr_bigquery_client
+    )
+    assert len(files_loaded) > 0, f"Should have loaded {file_type} data files"
+
+
+def assert_metadata_loaded(metadata_type: str, dataset_name: str, bq_project: str, tdr_bigquery_client: Client):
+    data_loaded = _query_metadata_table(
+        metadata_type,
+        dataset_name,
+        bq_project,
+        tdr_bigquery_client
+    )
+
+    assert len(data_loaded) > 0, f"Should have loaded {metadata_type} rows"
+
+
+def _query_metadata_table(metadata_type: str, dataset_name: str, bq_project: str, client: Client):
+    query = f"""
+    SELECT * FROM `datarepo_{dataset_name}.{metadata_type}`
+    """
+    return _exec_query(query, client, bq_project)
+
+
+def _query_files_loaded(file_type: str, dataset_name: str, bq_project: str, client: Client):
+    query = f"""
+    SELECT * FROM `datarepo_{dataset_name}.{file_type}` f
+    INNER JOIN `datarepo_{dataset_name}.datarepo_load_history` dlh
+    ON dlh.file_id = f.file_id
+    """
+    return _exec_query(query, client, bq_project)
+
+
+def _exec_query(query, client, bq_project):
+    job_config = QueryJobConfig()
+    job_config.use_legacy_sql = False
+
+    query_job = client.query(
+        query,
+        job_config,
+        location="US",
+        project=bq_project
+    )
+    result = query_job.result()
+    return [row for row in result]

--- a/orchestration/hca_orchestration/tests/support/bigquery.py
+++ b/orchestration/hca_orchestration/tests/support/bigquery.py
@@ -12,7 +12,7 @@ def assert_data_loaded(file_type: str, dataset_name: str, bq_project: str, tdr_b
 
 
 def assert_metadata_loaded(metadata_type: str, dataset_name: str, bq_project: str, tdr_bigquery_client: Client):
-    data_loaded = _query_metadata_table(
+    data_loaded = query_metadata_table(
         metadata_type,
         dataset_name,
         bq_project,
@@ -22,11 +22,11 @@ def assert_metadata_loaded(metadata_type: str, dataset_name: str, bq_project: st
     assert len(data_loaded) > 0, f"Should have loaded {metadata_type} rows"
 
 
-def _query_metadata_table(metadata_type: str, dataset_name: str, bq_project: str, client: Client):
+def query_metadata_table(metadata_type: str, dataset_name: str, bq_project: str, client: Client):
     query = f"""
     SELECT * FROM `datarepo_{dataset_name}.{metadata_type}`
     """
-    return _exec_query(query, client, bq_project)
+    return exec_query(query, client, bq_project)
 
 
 def _query_files_loaded(file_type: str, dataset_name: str, bq_project: str, client: Client):
@@ -35,10 +35,10 @@ def _query_files_loaded(file_type: str, dataset_name: str, bq_project: str, clie
     INNER JOIN `datarepo_{dataset_name}.datarepo_load_history` dlh
     ON dlh.file_id = f.file_id
     """
-    return _exec_query(query, client, bq_project)
+    return exec_query(query, client, bq_project)
 
 
-def _exec_query(query, client, bq_project):
+def exec_query(query, client, bq_project):
     job_config = QueryJobConfig()
     job_config.use_legacy_sql = False
 

--- a/orchestration/poetry.lock
+++ b/orchestration/poetry.lock
@@ -575,7 +575,7 @@ gevent = "*"
 
 [[package]]
 name = "google-api-core"
-version = "1.31.2"
+version = "1.31.4"
 description = "Google API client core library"
 category = "main"
 optional = false
@@ -586,7 +586,7 @@ google-auth = ">=1.25.0,<2.0dev"
 googleapis-common-protos = ">=1.6.0,<2.0dev"
 grpcio = {version = ">=1.29.0,<2.0dev", optional = true, markers = "extra == \"grpc\""}
 packaging = ">=14.3"
-protobuf = ">=3.12.0"
+protobuf = {version = ">=3.12.0", markers = "python_version > \"3\""}
 pytz = "*"
 requests = ">=2.18.0,<3.0.0dev"
 six = ">=1.13.0"
@@ -1053,7 +1053,7 @@ python-versions = "*"
 
 [[package]]
 name = "more-itertools"
-version = "8.10.0"
+version = "8.11.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "main"
 optional = false
@@ -1876,7 +1876,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.6"
-content-hash = "cf2835d99bdde214a2e2b59531b3524634750b47ebc7c2ca9650f199bea244c1"
+content-hash = "fb24afb7516a1c38865a4561d272177e1f066fdfaf40d83cce7125af768083a7"
 
 [metadata.files]
 aiohttp = [
@@ -2270,8 +2270,8 @@ gevent-websocket = [
     {file = "gevent_websocket-0.10.1-py3-none-any.whl", hash = "sha256:17b67d91282f8f4c973eba0551183fc84f56f1c90c8f6b6b30256f31f66f5242"},
 ]
 google-api-core = [
-    {file = "google-api-core-1.31.2.tar.gz", hash = "sha256:8500aded318fdb235130bf183c726a05a9cb7c4b09c266bd5119b86cdb8a4d10"},
-    {file = "google_api_core-1.31.2-py2.py3-none-any.whl", hash = "sha256:384459a0dc98c1c8cd90b28dc5800b8705e0275a673a7144a513ae80fc77950b"},
+    {file = "google-api-core-1.31.4.tar.gz", hash = "sha256:c77ffc8b4981b44efdb9d68431fd96d21dbd39545c29552bbe79b9b7dd2c3689"},
+    {file = "google_api_core-1.31.4-py2.py3-none-any.whl", hash = "sha256:ed59c6a695a81f601e4ba0f37ca9dbde3c43b3309e161a1a8946f266db4a0c4e"},
 ]
 google-api-python-client = [
     {file = "google-api-python-client-1.12.8.tar.gz", hash = "sha256:f3b9684442eec2cfe9f9bb48e796ef919456b82142c7528c5fd527e5224f08bb"},
@@ -2572,8 +2572,8 @@ mistune = [
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.10.0.tar.gz", hash = "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f"},
-    {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
+    {file = "more-itertools-8.11.0.tar.gz", hash = "sha256:0a2fd25d343c08d7e7212071820e7e7ea2f41d8fb45d6bc8a00cd6ce3b7aab88"},
+    {file = "more_itertools-8.11.0-py3-none-any.whl", hash = "sha256:88afff98d83d08fe5e4049b81e2b54c06ebb6b3871a600040865c7a592061cbb"},
 ]
 multidict = [
     {file = "multidict-5.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3822c5894c72e3b35aae9909bef66ec83e44522faf767c0ad39e0e2de11d3b55"},

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -41,6 +41,7 @@ check = "hca_manage.check:run"
 dataset = "hca_manage.dataset:run"
 snapshot = "hca_manage.snapshot:run"
 soft_delete = "hca_manage.soft_delete:run"
+job = "hca_manage.job:fetch_job_info"
 
 [build-system]
 requires = ["poetry-core=^1.1.8"]

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -21,10 +21,10 @@ typing-extensions = "^3.7.4"
 pyyaml = "^5.3"
 dagster-gcp = "^0.12.14"
 broad-dagster-utils = "0.6.7"
-hca-import-validation = "^0.0.3"
-more-itertools = "^8.8.0"
 graphql-ws = "<0.4.0"
 jsonschema = "3.2.0"
+hca-import-validation = "^0.0.3"
+more-itertools = "^8.11.0"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.5"

--- a/orchestration/pytest.ini
+++ b/orchestration/pytest.ini
@@ -11,5 +11,4 @@ addopts = -m "not e2e"
 log_cli = True
 log_level = INFO
 
-
 filterwarnings = ignore::dagster.ExperimentalWarning


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1930)
We need an end-to-end test in place for the copy project pipeline before we can proceed with the formal "new" production migration.

## This PR
* Adds the needed test. It loads a new HCA dataset in dev, snapshots it, copies the constituent project to a new dataset and asserts that the data was copied properly.

## Checklist
- [x] Documentation has been updated as needed.
