### PR TITLE
Fix legacy snapshot naming to pass regex, add test

### DIFF
--- a/orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -17,6 +17,7 @@ from hca_orchestration.solids.data_repo import wait_for_job_completion
 from hca_orchestration.resources.data_repo_service import data_repo_service
 from hca_orchestration.resources.config.data_repo import hca_manage_config, project_snapshot_creation_config, \
     snapshot_creation_config
+from hca_orchestration.resources.config.data_repo import run_start_time
 
 from hca_orchestration.resources.config.dagit import dagit_config
 
@@ -77,6 +78,7 @@ def legacy_cut_snapshot_job(hca_env: str, steward: str) -> PipelineDefinition:
             "slack": preconfigure_resource_for_mode(live_slack_client, hca_env),
             "snapshot_config": snapshot_creation_config,
             "dagit_config": preconfigure_resource_for_mode(dagit_config, hca_env),
+            "run_start_time": run_start_time
         },
         config={
             "resources": {

--- a/orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -17,7 +17,7 @@ from hca_orchestration.solids.data_repo import wait_for_job_completion
 from hca_orchestration.resources.data_repo_service import data_repo_service
 from hca_orchestration.resources.config.data_repo import hca_manage_config, project_snapshot_creation_config, \
     snapshot_creation_config
-from hca_orchestration.resources.config.data_repo import run_start_time
+from hca_orchestration.resources.utils import run_start_time
 
 from hca_orchestration.resources.config.dagit import dagit_config
 

--- a/orchestration/hca_orchestration/resources/config/data_repo.py
+++ b/orchestration/hca_orchestration/resources/config/data_repo.py
@@ -16,11 +16,6 @@ class SnapshotCreationConfig:
     managed_access: bool
 
 
-@resource
-def run_start_time(init_context: InitResourceContext) -> int:
-    return int(init_context.instance.get_run_stats(init_context.pipeline_run.run_id).start_time)
-
-
 @resource(
     required_resource_keys={"run_start_time"},
     config_schema={

--- a/orchestration/hca_orchestration/resources/utils.py
+++ b/orchestration/hca_orchestration/resources/utils.py
@@ -1,0 +1,6 @@
+from dagster import resource, InitResourceContext
+
+
+@resource
+def run_start_time(init_context: InitResourceContext) -> int:
+    return int(init_context.instance.get_run_stats(init_context.pipeline_run.run_id).start_time)

--- a/orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
+++ b/orchestration/hca_orchestration/tests/environments/test_create_snapshot.yaml
@@ -1,7 +1,7 @@
 resources:
   snapshot_config:
     config:
-      dataset_name: 'hca_dev_1f1a2b806abd4d2185301800b4320a88__20211101'
+      dataset_name: 'hca_dev_20201120_dcp2'
       managed_access: False
 solids:
   add_steward:

--- a/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
+++ b/orchestration/hca_orchestration/tests/pipelines/test_pipelines.py
@@ -139,6 +139,7 @@ def test_cut_snapshot(*mocks):
             "slack": console_slack_client,
             "snapshot_config": snapshot_creation_config,
             "dagit_config": preconfigure_resource_for_mode(dagit_config, "test"),
+            "run_start_time": ResourceDefinition.hardcoded_resource(123456)
         }
     )
     result = run_pipeline(job, config_name="test_create_snapshot.yaml")

--- a/orchestration/hca_orchestration/tests/resources/test_data_repo.py
+++ b/orchestration/hca_orchestration/tests/resources/test_data_repo.py
@@ -120,5 +120,4 @@ def test_snapshot_creation_config():
 
     config = snapshot_creation_config(init_context)
     result = search(LEGACY_SNAPSHOT_NAME_REGEX, config.snapshot_name)
-    print(config.snapshot_name)
     assert result, "Snapshot name should pass legacy snapshot regex"


### PR DESCRIPTION
## Why

The legacy cut snapshot job is failing because the name being generated is incorrect. 

## This PR
* Fixes the naming to add the needed underscores (3 vs 1)
* Adds a test ; as part of the test writing I needed to abstract the run start time to avoid a hard dependency on a running dagster instance, hence the refactor and new resource dep

## Checklist
- [ ] Documentation has been updated as needed.
