### PR TITLE
[DSPDC-1957] Chunk _fetch_file_entities call

### DIFF
--- a/orchestration/hca_orchestration/contrib/bigquery.py
+++ b/orchestration/hca_orchestration/contrib/bigquery.py
@@ -7,7 +7,12 @@ from typing import Optional
 
 from dagster_utils.contrib.google import GsBucketWithPrefix
 from google.cloud import bigquery
-from google.cloud.bigquery import ExternalConfig, WriteDisposition, ArrayQueryParameter, QueryJobConfig
+from google.cloud.bigquery import (
+    ArrayQueryParameter,
+    ExternalConfig,
+    QueryJobConfig,
+    WriteDisposition,
+)
 from google.cloud.bigquery.table import RowIterator
 
 from hca_orchestration.models.hca_dataset import TdrDataset


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1957)
This query also requires chunking to avoid going over the BQ API request size limit.

## This PR
Chunks the call, adds a test.
## Checklist
- [ ] Documentation has been updated as needed.
