### PR TITLE
Fix BQ project ID for DCP2 migration backfills

### DIFF
--- a/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
@@ -1,7 +1,7 @@
 resources:
   hca_project_copying_config:
     config:
-      source_bigquery_project_id: broad-datarepo-terra-prod-hca2
+      source_bigquery_project_id: tdr-fp-fea71bda
       source_snapshot_name: hca_prod_20201120_dcp2___2021213_dcp12
       source_bigquery_region: US
   load_tag:


### PR DESCRIPTION
## Why

We are using the DCP12 snapshot as the source for DCP2 based projects, the BQ project needs to reflect this and not be the base dataset's BQ project ID.

## This PR
* Sets the correct BQ project ID
## Checklist
- [ ] Documentation has been updated as needed.
