### PR TITLE
Use correct snapshot name for dcp2 migration

### DIFF
--- a/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
@@ -20,6 +20,7 @@ resources:
       policy_members: ["monster@firecloud.org"]
       billing_profile_id: 87bfdaf8-9216-4795-90c9-7ae5e7946871
       region: US
+      qualifier: dcp2
   hca_project_id:
     config: {}
 solids:

--- a/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
@@ -2,7 +2,7 @@ resources:
   hca_project_copying_config:
     config:
       source_bigquery_project_id: tdr-fp-fea71bda
-      source_snapshot_name: hca_prod_20201120_dcp2___2021213_dcp12
+      source_snapshot_name: hca_prod_20201120_dcp2___20211213_dcp12
       source_bigquery_region: US
   load_tag:
     config:


### PR DESCRIPTION
## Why

There is a typo in the source snapshot name for dcp2 migrated projects.

## This PR
* Fixes the typo
* Adds a dcp2 qualifier to better distinguish between projects migrated from dcp1 and dcp2.

## Checklist
- [ ] Documentation has been updated as needed.
