### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -55,7 +55,3 @@ jobs:
       run: poetry run pytest -v
       working-directory: ${{ github.workspace }}/orchestration
       if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails
-    - name: Run E2E test suite
-      run: poetry run pytest -v -m e2e hca_orchestration/tests/e2e/test_copy_project.py
-      working-directory: ${{ github.workspace }}/orchestration
-      if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -55,3 +55,7 @@ jobs:
       run: poetry run pytest -v
       working-directory: ${{ github.workspace }}/orchestration
       if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails
+    - name: Run E2E test suite
+      run: poetry run pytest -v -m e2e hca_orchestration/tests/e2e/test_copy_project.py
+      working-directory: ${{ github.workspace }}/orchestration
+      if: always() && steps.dependencies.outcome == 'success' # run all three checks, even if a prior check fails

--- a/orchestration/hca_orchestration/solids/validate_dataset.py
+++ b/orchestration/hca_orchestration/solids/validate_dataset.py
@@ -1,14 +1,27 @@
 from typing import Iterator
 
-from dagster import op, Failure, In, Nothing, AssetMaterialization, AssetKey, Out, Output
-from dagster.core.execution.context.compute import AbstractComputeExecutionContext
+from dagster import (
+    AssetKey,
+    AssetMaterialization,
+    Failure,
+    In,
+    Nothing,
+    Out,
+    Output,
+    op,
+)
+from dagster.core.execution.context.compute import (
+    AbstractComputeExecutionContext,
+)
 
-from hca_manage.common import ProblemCount
-from hca_orchestration.contrib.bigquery import BigQueryService
 from hca_manage.check import CheckManager
-from hca_orchestration.models.hca_dataset import TdrDataset
-from hca_orchestration.resources.hca_project_config import HcaProjectCopyingConfig
+from hca_manage.common import ProblemCount
 from hca_manage.verify_subgraphs import verify_all_subgraphs_in_dataset
+from hca_orchestration.contrib.bigquery import BigQueryService
+from hca_orchestration.models.hca_dataset import TdrDataset
+from hca_orchestration.resources.hca_project_config import (
+    HcaProjectCopyingConfig,
+)
 
 
 @op(
@@ -44,7 +57,7 @@ def verify_subgraphs(context: AbstractComputeExecutionContext, result: ProblemCo
     verify_all_subgraphs_in_dataset(
         links_rows,
         target_hca_dataset.project_id,
-        target_hca_dataset.dataset_name,
+        f"datarepo_{target_hca_dataset.dataset_name}",
         bigquery_service
     )
 


### PR DESCRIPTION
## Why

The previous commit broke the codepath as called from the copy project pipeline. 

## This PR
* Adjusts the copy project pipeline to prepend a `datarepo_` prefix to the dataset ID.
## Checklist
- [ ] Documentation has been updated as needed.
