### PR TITLE
Update source snapshot for prod migration to dcp13

### DIFF
--- a/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
@@ -1,8 +1,8 @@
 resources:
   hca_project_copying_config:
     config:
-      source_bigquery_project_id: tdr-fp-fea71bda
-      source_snapshot_name: hca_prod_20201120_dcp2___20211213_dcp12
+      source_bigquery_project_id: tdr-fp-a064907e
+      source_snapshot_name: hca_prod_20201120_dcp2___20220201_dcp13
       source_bigquery_region: US
   load_tag:
     config:

--- a/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/dcp2_real_prod_migration.yaml
@@ -1,8 +1,8 @@
 resources:
   hca_project_copying_config:
     config:
-      source_bigquery_project_id: tdr-fp-a064907e
-      source_snapshot_name: hca_prod_20201120_dcp2___20220201_dcp13
+      source_bigquery_project_id: tdr-fp-6fb8b81b
+      source_snapshot_name: hca_prod_20201120_dcp2___20220209_dcp13
       source_bigquery_region: US
   load_tag:
     config:


### PR DESCRIPTION
## Why

We need to update the "new" prod datasets with data from the dcp13 release.

## This PR
* Updates the source snapshot

## Checklist
- [ ] Documentation has been updated as needed.
