### PR TITLE
Full per-project load support

### DIFF
--- a/orchestration/hca_manage/soft_delete.py
+++ b/orchestration/hca_manage/soft_delete.py
@@ -1,19 +1,25 @@
 import argparse
-from dataclasses import dataclass, field
 import logging
-from typing import BinaryIO, Optional
 import uuid
+from dataclasses import dataclass, field
+from typing import BinaryIO, Optional
 
+import google.auth.credentials
 from dagster_utils.contrib import google as hca_google
 from dagster_utils.contrib.data_repo.jobs import poll_job
-from data_repo_client import RepositoryApi, DataDeletionRequest
-import google.auth.credentials
+from dagster_utils.contrib.data_repo.typing import JobId
+from data_repo_client import DataDeletionRequest, RepositoryApi
 from google.cloud import storage
 
-from dagster_utils.contrib.data_repo.typing import JobId
 from hca_manage import __version__ as hca_manage_version
-from hca_manage.common import data_repo_host, DefaultHelpParser, get_api_client, get_dataset_id, query_yes_no, \
-    setup_cli_logging_format
+from hca_manage.common import (
+    DefaultHelpParser,
+    data_repo_host,
+    get_api_client,
+    get_dataset_id,
+    query_yes_no,
+    setup_cli_logging_format,
+)
 
 
 def run(arguments: Optional[list[str]] = None) -> None:
@@ -21,7 +27,8 @@ def run(arguments: Optional[list[str]] = None) -> None:
 
     parser = DefaultHelpParser(description="A simple CLI to soft delete rows in a TDR dataset.")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s " + hca_manage_version)
-    parser.add_argument("-e", "--env", help="The Jade environment to target", choices=["dev", "prod"], required=True)
+    parser.add_argument("-e", "--env", help="The Jade environment to target",
+                        choices=["dev", "prod", "real_prod"], required=True)
 
     parser.add_argument("-p", "--path", help="Path to csv containing row IDs to soft delete")
     parser.add_argument("-t", "--target_table", help="Table containing the rows slated for soft deletion")
@@ -58,7 +65,7 @@ class SoftDeleteManager:
         self.bucket_project = {"prod": "mystical-slate-284720",
                                "real_prod": "mystical-slate-284720",
                                "dev": "broad-dsp-monster-hca-dev"}[self.environment]
-        self.bucket = f"broad-dsp-monster-hca-{self.environment}-staging-storage"
+        self.bucket = f"broad-dsp-monster-hca-prod-staging-storage"
 
     @property
     def gcp_creds(self) -> google.auth.credentials.Credentials:

--- a/orchestration/hca_manage/validation.py
+++ b/orchestration/hca_manage/validation.py
@@ -3,9 +3,9 @@ from typing import Any, Optional
 
 from dagster_utils.contrib.google import parse_gs_path
 from google.cloud.storage import Client
+from hca.staging_area_validator import StagingAreaValidator
 
 from hca_manage.common import DefaultHelpParser
-from hca.staging_area_validator import StagingAreaValidator
 
 
 class HcaValidator:
@@ -14,13 +14,12 @@ class HcaValidator:
         Run the validation pre-checks on the staging area
         :param path: Google Cloud Storage path for staging area
         """
-        exit_code = self.validate_structure(path, client)
         adapter = StagingAreaValidator(
             staging_area=path,
             ignore_dangling_inputs=ignore_inputs,
             validate_json=True
         )
-        exit_code |= adapter.main()
+        exit_code = adapter.main()
         if not exit_code:
             logging.info(f'Staging area {path} is valid')
         else:

--- a/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
+++ b/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
@@ -1,10 +1,11 @@
 import os
-import re
 from datetime import datetime
 
 from dagster import Partition, file_relative_path
 from dagster.utils import load_yaml_from_path
 from dagster_utils.typing import DagsterObjectConfigSchema
+
+from hca_orchestration.support.matchers import find_project_id_in_str
 
 
 def run_config_for_dcp_release_partition(partition: Partition) -> DagsterObjectConfigSchema:
@@ -36,12 +37,7 @@ def run_config_for_dcp_release_per_project_partition(partition: Partition) -> Da
     run_config["resources"]["load_tag"]["config"]["load_tag_prefix"] = load_prefix
 
     # TODO this is kind of a hack; we're looking for a UUID in the source path and assuming it's a project ID
-    uuid_matcher = re.compile('[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}', re.I)
-    project_ids = uuid_matcher.findall(partition.value)
-
-    if len(project_ids) != 1:
-        raise Exception(f"Found more than one or zero project UUIDs in {partition.value}")
-
-    run_config["resources"]["hca_project_id"]["config"]["hca_project_id"] = project_ids[0]
+    project_id = find_project_id_in_str(partition.value)
+    run_config["resources"]["hca_project_id"]["config"]["hca_project_id"] = project_id
 
     return run_config

--- a/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
+++ b/orchestration/hca_orchestration/config/dcp_release/dcp_release.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime
 
 from dagster import Partition, file_relative_path
@@ -18,4 +19,29 @@ def run_config_for_dcp_release_partition(partition: Partition) -> DagsterObjectC
     load_prefix = f"dcp_release_{creation_date}"
     run_config["resources"]["scratch_config"]["config"]["scratch_dataset_prefix"] = "staging"
     run_config["resources"]["load_tag"]["config"]["load_tag_prefix"] = load_prefix
+    return run_config
+
+
+def run_config_for_dcp_release_per_project_partition(partition: Partition) -> DagsterObjectConfigSchema:
+    path = file_relative_path(
+        __file__, os.path.join(f"./run_config/prod", "per_project_dcp_release.yaml")
+    )
+
+    run_config: DagsterObjectConfigSchema = load_yaml_from_path(path)
+    run_config["solids"]["pre_process_metadata"]["config"]["input_prefix"] = partition.value
+    creation_date = datetime.now().strftime("%Y%m%d%H%M")
+
+    load_prefix = f"dcp_release_{creation_date}"
+    run_config["resources"]["scratch_config"]["config"]["scratch_dataset_prefix"] = "staging"
+    run_config["resources"]["load_tag"]["config"]["load_tag_prefix"] = load_prefix
+
+    # TODO this is kind of a hack; we're looking for a UUID in the source path and assuming it's a project ID
+    uuid_matcher = re.compile('[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}', re.I)
+    project_ids = uuid_matcher.findall(partition.value)
+
+    if len(project_ids) != 1:
+        raise Exception(f"Found more than one or zero project UUIDs in {partition.value}")
+
+    run_config["resources"]["hca_project_id"]["config"]["hca_project_id"] = project_ids[0]
+
     return run_config

--- a/orchestration/hca_orchestration/config/dcp_release/run_config/prod/per_project_dcp_release.yaml
+++ b/orchestration/hca_orchestration/config/dcp_release/run_config/prod/per_project_dcp_release.yaml
@@ -1,0 +1,23 @@
+resources:
+  load_tag:
+    config:
+      append_run_id: true
+  scratch_config:
+    config:
+      scratch_bq_project: mystical-slate-284720
+      scratch_bucket_name: broad-dsp-monster-hca-prod-staging-storage
+      scratch_table_expiration_ms: 86400000
+  target_hca_dataset:
+    config:
+      env: "real_prod"
+      policy_members: ["monster@firecloud.org"]
+      billing_profile_id: 87bfdaf8-9216-4795-90c9-7ae5e7946871
+      region: US
+      qualifier: dcp2
+  hca_project_id:
+    config: {}
+solids:
+  pre_process_metadata:
+    config:
+      input_prefix:
+

--- a/orchestration/hca_orchestration/config/prod_migration/prod_migration.py
+++ b/orchestration/hca_orchestration/config/prod_migration/prod_migration.py
@@ -33,3 +33,17 @@ def run_config_cut_project_snapshot_job_real_prod_dcp2(partition: Partition) -> 
     run_config["resources"]["snapshot_config"]["config"]["source_hca_project_id"] = partition.value
 
     return run_config
+
+
+def run_config_per_project_snapshot_job(partition: Partition) -> DagsterObjectConfigSchema:
+    path = file_relative_path(
+        __file__, os.path.join("./run_config", "per_project_snapshot.yaml")
+    )
+    run_config: DagsterObjectConfigSchema = load_yaml_from_path(path)
+
+    # we bake the release tag into the uploaded partitions csv (i.e, <uuid>,<release tag>)
+    project_id, release_tag = partition.value.split(',')
+    run_config["resources"]["snapshot_config"]["config"]["source_hca_project_id"] = project_id
+    run_config["resources"]["snapshot_config"]["config"]["qualifier"] = release_tag
+
+    return run_config

--- a/orchestration/hca_orchestration/config/prod_migration/run_config/per_project_snapshot.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/per_project_snapshot.yaml
@@ -1,0 +1,9 @@
+resources:
+  snapshot_config:
+    config:
+      managed_access: false
+      dataset_qualifier: dcp2
+solids:
+  add_steward:
+    config:
+      snapshot_steward: monster@firecloud.org

--- a/orchestration/hca_orchestration/repositories/prod_repository.py
+++ b/orchestration/hca_orchestration/repositories/prod_repository.py
@@ -23,6 +23,7 @@ from hca_orchestration.config.prod_migration.prod_migration import (
     run_config_cut_project_snapshot_job_real_prod_dcp2,
     run_config_for_real_prod_migration_dcp1,
     run_config_for_real_prod_migration_dcp2,
+    run_config_per_project_snapshot_job,
 )
 from hca_orchestration.contrib.dagster import configure_partitions_for_pipeline
 from hca_orchestration.pipelines import copy_project
@@ -176,7 +177,7 @@ def all_jobs() -> list[PipelineDefinition]:
     jobs += configure_partitions_for_pipeline("dcp2_real_prod_migration",
                                               run_config_for_real_prod_migration_dcp2)
     jobs += configure_partitions_for_pipeline("cut_project_snapshot_job_real_prod",
-                                              run_config_cut_project_snapshot_job_real_prod_dcp2)
+                                              run_config_per_project_snapshot_job)
     jobs += configure_partitions_for_pipeline("load_hca", run_config_for_dcp_release_partition)
     jobs += configure_partitions_for_pipeline("per_project_load_hca",
                                               run_config_for_dcp_release_per_project_partition)

--- a/orchestration/hca_orchestration/repositories/prod_repository.py
+++ b/orchestration/hca_orchestration/repositories/prod_repository.py
@@ -70,6 +70,7 @@ def validate_ingress_job() -> PipelineDefinition:
 
 def load_hca_job() -> PipelineDefinition:
     return load_hca.to_job(
+        name="load_hca",
         resource_defs={
             "beam_runner": preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "prod"),
             "bigquery_client": bigquery_client,
@@ -88,9 +89,9 @@ def load_hca_job() -> PipelineDefinition:
     )
 
 
-def load_hca_per_project_job() -> PipelineDefinition:
+def per_project_load_hca() -> PipelineDefinition:
     return load_hca.to_job(
-        name="load_hca_per_project_job",
+        name="per_project_load_hca",
         resource_defs={
             "beam_runner": preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "prod"),
             "bigquery_client": bigquery_client,
@@ -158,7 +159,7 @@ def dcp2_real_prod_migration() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        load_hca_per_project_job(),
+        per_project_load_hca(),
         dcp1_real_prod_migration(),
         dcp2_real_prod_migration(),
         cut_project_snapshot_job("prod", "prod", "monster@firecloud.org"),
@@ -177,7 +178,7 @@ def all_jobs() -> list[PipelineDefinition]:
     jobs += configure_partitions_for_pipeline("cut_project_snapshot_job_real_prod",
                                               run_config_cut_project_snapshot_job_real_prod_dcp2)
     jobs += configure_partitions_for_pipeline("load_hca", run_config_for_dcp_release_partition)
-    jobs += configure_partitions_for_pipeline("load_hca_per_project_job",
+    jobs += configure_partitions_for_pipeline("per_project_load_hca",
                                               run_config_for_dcp_release_per_project_partition)
     jobs += configure_partitions_for_pipeline("validate_ingress", run_config_for_validation_ingress_partition)
 

--- a/orchestration/hca_orchestration/repositories/prod_repository.py
+++ b/orchestration/hca_orchestration/repositories/prod_repository.py
@@ -158,7 +158,7 @@ def dcp2_real_prod_migration() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
-        load_hca_per_project_job()
+        load_hca_per_project_job(),
         dcp1_real_prod_migration(),
         dcp2_real_prod_migration(),
         cut_project_snapshot_job("prod", "prod", "monster@firecloud.org"),

--- a/orchestration/hca_orchestration/repositories/prod_repository.py
+++ b/orchestration/hca_orchestration/repositories/prod_repository.py
@@ -17,6 +17,7 @@ from dagster_utils.resources.slack import live_slack_client
 from hca_orchestration.config import preconfigure_resource_for_mode
 from hca_orchestration.config.dcp_release.dcp_release import (
     run_config_for_dcp_release_partition,
+    run_config_for_dcp_release_per_project_partition,
 )
 from hca_orchestration.config.prod_migration.prod_migration import (
     run_config_cut_project_snapshot_job_real_prod_dcp2,
@@ -87,6 +88,29 @@ def load_hca_job() -> PipelineDefinition:
     )
 
 
+def load_hca_per_project_job() -> PipelineDefinition:
+    return load_hca.to_job(
+        name="load_hca_per_project_job",
+        resource_defs={
+            "beam_runner": preconfigure_resource_for_mode(k8s_dataflow_beam_runner, "prod"),
+            "bigquery_client": bigquery_client,
+            "data_repo_client": preconfigure_resource_for_mode(jade_data_repo_client, "real_prod"),
+            "gcs": google_storage_client,
+            "io_manager": preconfigure_resource_for_mode(gcs_pickle_io_manager, "prod"),
+            "load_tag": load_tag,
+            "scratch_config": scratch_config,
+            "target_hca_dataset": find_or_create_project_dataset,
+            "bigquery_service": bigquery_service,
+            "data_repo_service": data_repo_service,
+            "run_start_time": run_start_time,
+            "hca_project_id": hca_project_id,
+            "slack": preconfigure_resource_for_mode(live_slack_client, "prod"),
+            "dagit_config": preconfigure_resource_for_mode(dagit_config, "prod")
+        },
+        executor_def=in_process_executor
+    )
+
+
 def dcp1_real_prod_migration() -> PipelineDefinition:
     return copy_project.to_job(
         name=f"dcp1_real_prod_migration",
@@ -134,6 +158,7 @@ def dcp2_real_prod_migration() -> PipelineDefinition:
 @repository
 def all_jobs() -> list[PipelineDefinition]:
     jobs = [
+        load_hca_per_project_job()
         dcp1_real_prod_migration(),
         dcp2_real_prod_migration(),
         cut_project_snapshot_job("prod", "prod", "monster@firecloud.org"),
@@ -143,7 +168,7 @@ def all_jobs() -> list[PipelineDefinition]:
         validate_ingress_job(),
         slack_on_pipeline_start,
         slack_on_pipeline_success,
-        build_pipeline_failure_sensor(),
+        build_pipeline_failure_sensor()
     ]
     jobs += configure_partitions_for_pipeline("dcp1_real_prod_migration",
                                               run_config_for_real_prod_migration_dcp1)
@@ -152,6 +177,8 @@ def all_jobs() -> list[PipelineDefinition]:
     jobs += configure_partitions_for_pipeline("cut_project_snapshot_job_real_prod",
                                               run_config_cut_project_snapshot_job_real_prod_dcp2)
     jobs += configure_partitions_for_pipeline("load_hca", run_config_for_dcp_release_partition)
+    jobs += configure_partitions_for_pipeline("load_hca_per_project_job",
+                                              run_config_for_dcp_release_per_project_partition)
     jobs += configure_partitions_for_pipeline("validate_ingress", run_config_for_validation_ingress_partition)
 
     return jobs

--- a/orchestration/hca_orchestration/support/matchers.py
+++ b/orchestration/hca_orchestration/support/matchers.py
@@ -1,0 +1,11 @@
+import re
+
+
+def find_project_id_in_str(s: str) -> str:
+    uuid_matcher = re.compile('[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}', re.I)
+    project_ids = uuid_matcher.findall(s)
+
+    if len(project_ids) != 1:
+        raise Exception(f"Found more than one or zero project UUIDs in {s}")
+
+    return str(project_ids[0])

--- a/orchestration/hca_orchestration/tests/support/test_matchers.py
+++ b/orchestration/hca_orchestration/tests/support/test_matchers.py
@@ -1,0 +1,24 @@
+import pytest
+
+from hca_orchestration.support.matchers import find_project_id_in_str
+
+
+def test_find_project_id_in_str():
+    test_str = "foo/b/ar/bbaz/4d6f6c96-2a83-43d8-8fe1-0f53bffd4674//bar/bar"
+    project_id = find_project_id_in_str(test_str)
+
+    assert project_id == '4d6f6c96-2a83-43d8-8fe1-0f53bffd4674'
+
+
+def test_find_project_id_fails_multiples():
+    test_str = "foo/b/ar/bbaz/4d6f6c96-2a83-43d8-8fe1-0f53bffd4674//bar/bar/88ec040b-8705-4f77-8f41-f81e57632f7d"
+
+    with pytest.raises(Exception):
+        find_project_id_in_str(test_str)
+
+
+def test_find_project_id_fails_none():
+    test_str = "example"
+
+    with pytest.raises(Exception):
+        find_project_id_in_str(test_str)


### PR DESCRIPTION
## Why

We are importing to new prod so our release infrastructure needs to support the new loading methodology.

## This PR
* Adds a new `load_hca_per_project` job that knows how to determine a project_id and consequent dataset given a source staging path and
* Updates the manifest generator tool to understand the new `institution, project_id` manifest format. 

## Checklist
- [ ] Documentation has been updated as needed.
