### PR TITLE
[DSPDC-1968] Add support for file_descriptors with drs_uris

### DIFF
--- a/orchestration/hca_manage/bq_managers.py
+++ b/orchestration/hca_manage/bq_managers.py
@@ -1,11 +1,10 @@
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
 import logging
 import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Callable
 
 from google.cloud import bigquery
-
 
 from hca_manage.common import populate_row_id_csv
 from hca_manage.soft_delete import SoftDeleteManager
@@ -215,9 +214,13 @@ class NullFileRefManager(BQRowManager):
         :param target_table: The particular table to operate on.
         :return: A set of row ids to soft delete.
         """
+
+        # TODO we are allowing null file_ids if there is a `drs_uri` field in the descriptor (these are
+        # "bring your own" DRS file references that are hosted outside of TDR). We should be smarter about parsing
+        # the descriptor and ensuring a sane value rather than the fuzzy matching we're doing here
         query = f"""
         SELECT datarepo_row_id
-        FROM `{self.project}.{self.dataset}.{target_table}` WHERE file_id IS NULL
+        FROM `{self.project}.{self.dataset}.{target_table}` WHERE file_id IS NULL AND descriptor NOT LIKE '%"drs_uri":%'
         """
 
         return self._hit_bigquery(query)

--- a/orchestration/hca_orchestration/config/dcp_release/run_config/prod/per_project_dcp_release.yaml
+++ b/orchestration/hca_orchestration/config/dcp_release/run_config/prod/per_project_dcp_release.yaml
@@ -14,6 +14,7 @@ resources:
       billing_profile_id: 87bfdaf8-9216-4795-90c9-7ae5e7946871
       region: US
       qualifier: dcp2
+      atlas: hca
   hca_project_id:
     config: {}
 solids:

--- a/orchestration/hca_orchestration/pipelines/cut_snapshot.py
+++ b/orchestration/hca_orchestration/pipelines/cut_snapshot.py
@@ -60,6 +60,7 @@ def cut_project_snapshot_job(hca_env: str, jade_env: str, steward: str) -> Pipel
                         "managed_access": False,
                         "source_hca_project_id": "",
                         "qualifier": None,
+                        "atlas": "hca"
                     }
                 }
             }, "solids": {

--- a/orchestration/hca_orchestration/resources/config/datasets.py
+++ b/orchestration/hca_orchestration/resources/config/datasets.py
@@ -3,9 +3,11 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from dagster import InitResourceContext, resource, Array, Field, Noneable
+from dagster import Array, Field, InitResourceContext, Noneable, resource
 
-from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
+from hca_orchestration.contrib.data_repo.data_repo_service import (
+    DataRepoService,
+)
 from hca_orchestration.models.hca_dataset import TdrDataset
 from hca_orchestration.support.dates import dataset_snapshot_formatted_date
 
@@ -33,6 +35,7 @@ def passthrough_hca_dataset(init_context: InitResourceContext) -> TdrDataset:
         "region": str,
         "policy_members": Array(str),
         "billing_profile_id": str,
+        "atlas": str,
         "qualifier": Field(Noneable(str), default_value=None, is_required=False),
     },
     required_resource_keys={"hca_project_id", "data_repo_service", "run_start_time"}
@@ -48,9 +51,10 @@ def find_or_create_project_dataset(init_context: InitResourceContext) -> Optiona
     hca_project_id = uuid.UUID(init_context.resources.hca_project_id)
     qualifier = init_context.resource_config['qualifier']
     env = init_context.resource_config['env']
+    atlas = init_context.resource_config['atlas']
     env_prefix = "prod" if env == "real_prod" else env
 
-    target_hca_dataset_prefix = f"hca_{env_prefix}_{hca_project_id.hex.replace('-', '')}"
+    target_hca_dataset_prefix = f"{atlas}_{env_prefix}_{hca_project_id.hex.replace('-', '')}"
     run_start_time = init_context.resources.run_start_time
     creation_date = dataset_snapshot_formatted_date(datetime.utcfromtimestamp(run_start_time))
 

--- a/orchestration/hca_orchestration/tests/resources/config/test_datasets.py
+++ b/orchestration/hca_orchestration/tests/resources/config/test_datasets.py
@@ -1,10 +1,14 @@
 from unittest.mock import Mock
 
-from dagster import build_init_resource_context, ResourceDefinition
+from dagster import ResourceDefinition, build_init_resource_context
 
-from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
-from hca_orchestration.resources.config.datasets import find_or_create_project_dataset
+from hca_orchestration.contrib.data_repo.data_repo_service import (
+    DataRepoService,
+)
 from hca_orchestration.models.hca_dataset import TdrDataset
+from hca_orchestration.resources.config.datasets import (
+    find_or_create_project_dataset,
+)
 
 
 def test_find_or_create_project_dataset_returns_existing_dataset():
@@ -24,7 +28,8 @@ def test_find_or_create_project_dataset_returns_existing_dataset():
             "region": "US",
             "policy_members": ["example@example.com"],
             "billing_profile_id": "fake_billing_profile_id",
-            "qualifier": None
+            "qualifier": None,
+            "atlas": "hca"
         },
         resources={
             "hca_project_id": ResourceDefinition.hardcoded_resource("08BCA7FF-A15A-4D58-806B-7CD45979768B"),
@@ -50,7 +55,8 @@ def test_find_or_create_project_dataset_creates_new_dataset():
             "region": "US",
             "policy_members": ["example@example.com"],
             "billing_profile_id": "fake_billing_profile_id",
-            "qualifier": None
+            "qualifier": None,
+            "atlas": "hca"
         },
         resources={
             "hca_project_id": ResourceDefinition.hardcoded_resource("08BCA7FF-A15A-4D58-806B-7CD45979768B"),
@@ -83,7 +89,8 @@ def test_find_or_create_project_dataset_creates_new_dataset_with_qualifier():
             "region": "US",
             "policy_members": ["example@example.com"],
             "billing_profile_id": "fake_billing_profile_id",
-            "qualifier": "test_qualifier"
+            "qualifier": "test_qualifier",
+            "atlas": "hca"
         },
         resources={
             "hca_project_id": ResourceDefinition.hardcoded_resource("08BCA7FF-A15A-4D58-806B-7CD45979768B"),
@@ -115,7 +122,8 @@ def test_find_or_create_project_dataset_transforms_real_prod_to_prod():
             "region": "US",
             "policy_members": ["example@example.com"],
             "billing_profile_id": "fake_billing_profile_id",
-            "qualifier": None
+            "qualifier": None,
+            "atlas": "hca"
         },
         resources={
             "hca_project_id": ResourceDefinition.hardcoded_resource("08BCA7FF-A15A-4D58-806B-7CD45979768B"),

--- a/orchestration/hca_orchestration/tests/resources/test_data_repo.py
+++ b/orchestration/hca_orchestration/tests/resources/test_data_repo.py
@@ -1,15 +1,20 @@
-from unittest.mock import MagicMock, Mock
 from datetime import datetime
 from re import search
+from unittest.mock import MagicMock, Mock
 
 import pytest
-from dagster import build_init_resource_context, ResourceDefinition
+from dagster import ResourceDefinition, build_init_resource_context
 
-from hca_orchestration.contrib.data_repo.data_repo_service import DataRepoService
-from hca_orchestration.resources.config.data_repo import project_snapshot_creation_config, snapshot_creation_config
-from hca_orchestration.models.hca_dataset import TdrDataset
-from hca_orchestration.support.dates import dataset_snapshot_formatted_date
 from hca_manage.snapshot import LEGACY_SNAPSHOT_NAME_REGEX
+from hca_orchestration.contrib.data_repo.data_repo_service import (
+    DataRepoService,
+)
+from hca_orchestration.models.hca_dataset import TdrDataset
+from hca_orchestration.resources.config.data_repo import (
+    project_snapshot_creation_config,
+    snapshot_creation_config,
+)
+from hca_orchestration.support.dates import dataset_snapshot_formatted_date
 
 
 def test_project_snapshot_creation_config(monkeypatch):
@@ -29,7 +34,8 @@ def test_project_snapshot_creation_config(monkeypatch):
             "source_hca_project_id": "abc123",
             "qualifier": "dcp999",
             "managed_access": False,
-            "dataset_qualifier": "dcp1"
+            "dataset_qualifier": "dcp1",
+            "atlas": "hca"
         }
     )
 
@@ -49,7 +55,8 @@ def test_project_snapshot_creation_config_none_found(monkeypatch):
             "source_hca_project_id": "abc123",
             "qualifier": "dcp999",
             "managed_access": False,
-            "dataset_qualifier": "dcp1"
+            "dataset_qualifier": "dcp1",
+            "atlas": "hca"
         }
     )
 
@@ -74,6 +81,7 @@ def test_project_snapshot_creation_config_no_dataset_qualifier(monkeypatch):
             "source_hca_project_id": "abc123",
             "qualifier": "dcp999",
             "managed_access": False,
+            "atlas": "hca"
         }
     )
 
@@ -99,6 +107,7 @@ def test_project_snapshot_creation_config_no_snapshot_qualifier(monkeypatch):
         config={
             "source_hca_project_id": "abc123",
             "managed_access": False,
+            "atlas": "hca"
         }
     )
 

--- a/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/hca/HcaPipelineBuilderSpec.scala
@@ -204,7 +204,7 @@ class HcaPipelineBuilderSpec extends AnyFlatSpec with Matchers with PipelineSpec
         """
           | {
           |   "source_path": "some/local/directory/data/a-directory/sub_directory/file-id_file-version_filename.json",
-          |   "target_path": "/v1/my-file-id/54321zyx/file-id_file-version_filename.json"
+          |   "target_path": "/v1/my-file-id/54321zyx/a-directory/sub_directory/file-id_file-version_filename.json"
           | }
           |""".stripMargin
     )


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1968)
We need to support the use case where a consortium brings their own DRS URIs, rather than relying on us to ingest and host files in TDR.

## This PR
* Adds support for the `drs_uri` field in a file descriptor. If present, we will not generate a file ingest request for the file, and will allow a NULL `file_id` field for the associated
metadata row

## Checklist
- [x] Documentation has been updated as needed.
