### PR TITLE
Pin markupsafe version

### DIFF
--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0.2.1
         with:
           project_id: ${{ secrets.DEV_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_TEST_KEY }}

--- a/.github/workflows/validate-python.yaml
+++ b/.github/workflows/validate-python.yaml
@@ -15,7 +15,7 @@ jobs:
       ENV: test
     steps:
     - uses: actions/checkout@v2
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0.2.1
       with:
         project_id: ${{ secrets.DEV_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_TEST_KEY }}

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -24,6 +24,7 @@ broad-dagster-utils = "0.6.7"
 graphql-ws = "<0.4.0"
 hca-import-validation = "^0.0.4"
 rfc3339-validator = "^0.1.4"
+markupsafe = "2.0.1"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.5"


### PR DESCRIPTION
## Why

There is a breaking change in the latest version of markupsafe

## This PR
* Pins to the markupsafe to the last known good version
* Fixes the setup-gcloud action invocations as well

