### PR TITLE
Add needed atlas config entry

### DIFF
--- a/orchestration/hca_orchestration/config/prod_migration/run_config/per_project_snapshot.yaml
+++ b/orchestration/hca_orchestration/config/prod_migration/run_config/per_project_snapshot.yaml
@@ -3,6 +3,7 @@ resources:
     config:
       managed_access: false
       dataset_qualifier: dcp2
+      atlas: hca
 solids:
   add_steward:
     config:


### PR DESCRIPTION
## Why

We added an atlas configuration entry for snapshots, the backfill partition config needs the atlas config entry as well.

## This PR
* Adds the config entry

