### PR TITLE
refactored GitHub Actions to test on PR (and syncs to PRs) and build/…

### DIFF
--- a/.github/workflows/build-and-publish-main.yaml
+++ b/.github/workflows/build-and-publish-main.yaml
@@ -1,6 +1,6 @@
 name: Main Validation and Release
 on:
-  pull_request:
+  push:
     branches:
       - main
 jobs:
@@ -10,48 +10,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Fetch tag history
         run: git fetch --tags
-      - uses: google-github-actions/setup-gcloud@v0.2.1
-        name: Setup gcloud for Dataflow tests
-        with:
-          project_id: ${{ secrets.DEV_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_TEST_KEY }}
-          export_default_credentials: true
-      - name: Set up Python 3.9 for dataflow tests
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9.16
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.2
-        with:
-          version: 1.1.9
-      - name: Restore cache dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-poetry-v2
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./orchestration/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Install dependencies
-        run: poetry install
-        working-directory: ${{ github.workspace }}/orchestration
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
-      - name: Check Scala formatting
-        run: sbt scalafmtCheckAll
-      - name: Scala Compile
-        run: sbt Compile/compile Test/compile IntegrationTest/compile
-      - name: Scala Test
-        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      - name: Run E2E test suite
-        run: poetry run pytest -v -m e2e
-        working-directory: ${{ github.workspace }}/orchestration
-      - name: Publish Scala coverage
-        uses: codecov/codecov-action@v1
       - uses: google-github-actions/setup-gcloud@v0.2.1
         name: Setup gcloud for pushing Docker images
         with:
@@ -70,7 +31,7 @@ jobs:
         with:
           context: ./orchestration
           push: true
-          tags: us.gcr.io/broad-dsp-gcr-public/monster-hca-dagster:${{steps.get-artifact-slug.outputs.slug}}, us.gcr.io/broad-dsp-gcr-public/monster-hca-dagster:latest, us.gcr.io/broad-dsp-gcr-public/monster-hca-dagster:di273
+          tags: us.gcr.io/broad-dsp-gcr-public/monster-hca-dagster:${{steps.get-artifact-slug.outputs.slug}}, us.gcr.io/broad-dsp-gcr-public/monster-hca-dagster:latest
 # leaving off for now as it is not needed for this update for DI-273 - new scratch bucket in US multi-region
 #      - name: Push Compose Dev Env Docker image
 #        uses: docker/build-push-action@v2

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -13,14 +13,39 @@ jobs:
           project_id: ${{ secrets.DEV_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_TEST_KEY }}
           export_default_credentials: true
+      - name: Set up Python 3.9 for dataflow tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.16
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.2
+        with:
+          version: 1.1.9
+      - name: Restore cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-poetry-v2
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./orchestration/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: poetry install
+        working-directory: ${{ github.workspace }}/orchestration
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
-      - name: Check formatting
+      - name: Check Scala formatting
         run: sbt scalafmtCheckAll
-      - name: Compile
+      - name: Scala Compile
         run: sbt Compile/compile Test/compile IntegrationTest/compile
-      - name: Test
+      - name: Scala Test
         run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
-      - name: Publish coverage
+      - name: Publish Scala Test coverage
         uses: codecov/codecov-action@v1
+      - name: Run E2E test suite
+        run: poetry run pytest -v -m e2e
+        working-directory: ${{ github.workspace }}/orchestration


### PR DESCRIPTION
…push Docker images on merge to Main

## Why

The permissions to push to GCR are saved in Git Secrets and we have to deploy to prod from a main hash, so we have to build a new Docker image when we merge to main.

Refactored so that we now run all of the validation (Scala & e2e pytests) on PR to main (and any subsequent syncs) and then we build & push new Docker images when we merge to main. 

That way we get our diagnostics before merging, and get our main hash at merge.

## This PR

## Checklist
- [X] Documentation has been updated as needed.
