### PR TITLE
FE-45 add GitHub action to recreate req.txt on pr to main

### DIFF
--- a/.github/workflows/generate-requirements-file.yaml
+++ b/.github/workflows/generate-requirements-file.yaml
@@ -1,0 +1,52 @@
+name: Generate requirements file
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  generate-requirements-file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.16
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.2
+        with:
+          version: 1.1.9
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      #This is important since a lock file is required for the next step
+      - name: Generate a lock file
+        run: poetry lock --no-interaction
+        working-directory: ${{ github.workspace }}/orchestration
+
+
+      - name: Generate requirements.txt
+        run: poetry export -f requirements.txt --without-hashes --no-interaction --output requirements.txt
+        working-directory: ${{ github.workspace }}/orchestration
+
+      - name: Commit requirements.txt
+        run: |
+          git config --local user.email "dsp-fieldeng@broadinstitute.org"
+          git config --local user.name "dsp-fieldeng-bot"
+          git add orchestration/requirements.txt
+          git commit -m "Update requirements.txt" --allow-empty
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v7
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.branch-name.outputs.current_branch }} # Pushes to the branch the action is run on
+          force: true

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__
 .pytest_cache
 dagster_home/
 venv/
+# Build files
+build/

--- a/orchestration/hca_manage/manifest.py
+++ b/orchestration/hca_manage/manifest.py
@@ -181,7 +181,7 @@ def load(args: argparse.Namespace) -> None:
         args.env,
         args.csv_path,
         args.release_tag,
-        f"cut_project_snapshot_{ENV_PIPELINE_ENDINGS[args.env]}",
+        f"cut_project_snapshot_job_{ENV_PIPELINE_ENDINGS[args.env]}",
         project_id_only=True,
         include_release_tag=True
     )

--- a/orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/hca_orchestration/solids/create_snapshot.py
@@ -117,7 +117,7 @@ def get_snapshot_from_project(context: AbstractComputeExecutionContext) -> Any:
             [release_tag={release_tag}].")
     response = context.resources.data_repo_client.enumerate_snapshots(filter=dataset_name)
     if len(response.items) != 1:
-        raise Failure("There is more than one snapshot matching this dataset_name")
+        logging.warning("There is more than one snapshot matching this dataset_name")
     snapshot_id = response.items[0].id
     return snapshot_id
 

--- a/orchestration/requirements.txt
+++ b/orchestration/requirements.txt
@@ -1,132 +1,99 @@
-#
-# added for SourceClear scans THIS IS NOT FOR INSTALLING REQUIREMENTS - USE POETRY - see the root README
-#
-aiohttp==3.8.4; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
+aiohttp==3.8.5; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 aiosignal==1.3.1; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 alembic==1.6.5; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-aniso8601==7.0.0
 argo-workflows==5.0.0
-async-timeout==4.0.2; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-attrs==22.2.0; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-beautifulsoup4==4.11.2; python_full_version >= "3.6.0" and python_version >= "3.6"
-bleach==6.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
+async-timeout==4.0.3; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
+attrs==23.1.0; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
+beautifulsoup4==4.12.2; python_full_version >= "3.6.0" and python_version >= "3.6"
 broad-dagster-utils==0.6.7; python_version >= "3.9" and python_version < "3.10"
 cached-property==1.5.2
-cachetools==5.3.0; python_version >= "3.7" and python_version < "4.0" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"))
-certifi==2022.12.7; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-cffi==1.15.1; platform_python_implementation == "CPython" and sys_platform == "win32" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_version > "3.5")
-charset-normalizer==3.1.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") and python_full_version >= "3.7.0"
+cachetools==5.3.1; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10"
+certifi==2023.7.22; python_version >= "3.9" and python_version < "3.10"
+charset-normalizer==3.2.0; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.7.0"
 click==7.1.2; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
 colorama==0.4.6; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and platform_system == "Windows" or python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows" and python_full_version >= "3.7.0"
 coloredlogs==14.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
-croniter==1.3.8; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.4.0"
-dagit==0.12.14
+croniter==1.4.1; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.4.0"
 dagster-gcp==0.12.14
-dagster-graphql==0.12.14
 dagster-k8s==0.12.14
 dagster-pandas==0.12.14
 dagster-postgres==0.12.14
 dagster-slack==0.12.14
 dagster==0.12.14
-data-repo-client==1.460.0
-defusedxml==0.7.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+data-repo-client==1.518.0
 docstring-parser==0.15; python_version >= "3.9" and python_version < "3.10"
-entrypoints==0.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-fastjsonschema==2.16.3; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-flask-cors==3.0.10
-flask-graphql==2.0.1
-flask-sockets==0.2.1
-flask==1.1.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-frozenlist==1.3.3; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-gevent-websocket==0.10.1
-gevent==22.10.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_version > "3.5" and python_full_version < "3.0.0" or python_version > "3.5"
-google-api-core==2.11.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+frozenlist==1.4.0; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
+google-api-core==2.11.1; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 google-api-python-client==1.12.11; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth-httplib2==0.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-google-auth==2.16.2; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+google-auth==2.17.3; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10"
 google-cloud-bigquery==2.34.3; python_version >= "3.6" and python_version < "3.11"
-google-cloud-core==2.3.2; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
+google-cloud-core==2.3.3; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
 google-cloud-storage==1.44.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-google-crc32c==1.5.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
-google-resumable-media==2.4.1; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
+google-crc32c==1.5.0; python_version >= "3.9" and python_version < "3.10"
+google-resumable-media==2.5.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
 google==3.0.0; python_version >= "3.6"
-googleapis-common-protos==1.58.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-gql==2.0.0
-graphene==2.1.9
+googleapis-common-protos==1.60.0; python_version >= "3.9" and python_version < "3.10"
 graphql-core==2.3.2
-graphql-relay==2.0.1
-graphql-server-core==1.2.0
 graphql-ws==0.3.1
-greenlet==2.0.2; python_version >= "3" and python_full_version < "3.0.0" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and platform_python_implementation == "CPython" or python_version > "3.5" and python_full_version < "3.0.0" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and platform_python_implementation == "CPython" or python_version > "3.5" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and python_full_version >= "3.5.0" and platform_python_implementation == "CPython"
+greenlet==2.0.2; python_version >= "3" and python_full_version < "3.0.0" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") or python_version >= "3" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and python_full_version >= "3.5.0"
 grpcio-health-checking==1.48.2; python_version >= "3.9" and python_version < "3.10"
-grpcio-status==1.48.2; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-grpcio==1.52.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-hca-import-validation==0.0.16; python_version >= "3.6"
-httplib2==0.21.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+grpcio-status==1.48.2; python_version >= "3.9" and python_version < "3.10"
+grpcio==1.57.0; python_version >= "3.9" and python_version < "3.10"
+hca-import-validation==0.0.17; python_version >= "3.6"
+httplib2==0.22.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 humanfriendly==10.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
-idna==3.4; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") and python_full_version >= "3.6.0"
-itsdangerous==1.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+idna==3.4; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 jinja2==2.11.3; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
-jsonschema==4.17.3; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-jupyter-core==5.3.0; python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.8"
-kubernetes==26.1.0; python_version >= "3.6"
+jsonschema-specifications==2023.7.1; python_version >= "3.8"
+jsonschema==4.19.0; python_version >= "3.8"
+kubernetes==27.2.0; python_version >= "3.6"
 mako==1.2.2; python_version >= "3.7"
 markupsafe==2.0.1; python_version >= "3.6"
-mistune==0.8.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-more-itertools==9.1.0; python_version >= "3.7"
+more-itertools==10.1.0; python_version >= "3.8"
 multidict==6.0.4; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-nbconvert==5.6.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-nbformat==5.7.3; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-numpy==1.24.2; python_version < "3.10" and python_version >= "3.8"
+numpy==1.25.2; python_version < "3.11" and python_version >= "3.9"
 oauth2client==4.1.3
 oauthlib==3.2.2; python_version >= "3.6"
-packaging==23.0; python_version >= "3.9" and python_version < "3.10"
-pandas==1.5.3; python_version >= "3.8"
-pandocfilters==1.5.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+packaging==23.1; python_version >= "3.9" and python_version < "3.10"
+pandas==2.1.0; python_version >= "3.9"
 pendulum==2.1.2; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
-platformdirs==3.1.1; python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.8"
 promise==2.3
-proto-plus==1.22.2; python_version >= "3.9" and python_version < "3.10"
+proto-plus==1.22.3; python_version >= "3.9" and python_version < "3.10"
 protobuf==3.20.2; python_version >= "3.7"
-psutil==5.9.4; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and platform_system == "Windows" or python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows" and python_full_version >= "3.4.0"
-psycopg2-binary==2.9.5; python_version >= "3.6"
-pyasn1-modules==0.2.8; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-pyasn1==0.4.8; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")) or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"))
-pycparser==2.21; python_version >= "2.7" and python_full_version < "3.0.0" and platform_python_implementation == "CPython" and sys_platform == "win32" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_version > "3.5") or platform_python_implementation == "CPython" and sys_platform == "win32" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_version > "3.5") and python_full_version >= "3.4.0"
-pygments==2.14.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-pyparsing==3.0.9; python_full_version >= "3.6.8" and python_version > "3.0"
+psutil==5.9.5; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and platform_system == "Windows" or python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows" and python_full_version >= "3.4.0"
+psycopg2-binary==2.9.7; python_version >= "3.6"
+pyasn1-modules==0.3.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10"
+pyasn1==0.5.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.6.0"
+pyparsing==3.1.1; python_full_version >= "3.6.8" and python_version > "3.0"
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.8" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0")
-pyrsistent==0.19.3; python_version >= "3.7"
 python-dateutil==2.8.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 python-editor==1.0.4; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-pytz==2022.7.1; python_version >= "3.9" and python_version < "3.10"
+pytz==2023.3; python_version >= "3.9" and python_version < "3.10"
 pytzdata==2020.1; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
-pywin32==305; python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows" and sys_platform == "win32" and platform_python_implementation != "PyPy" and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.8")
+pywin32==306; python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows"
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+referencing==0.30.2; python_version >= "3.8"
 requests-oauthlib==1.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-requests==2.28.2; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
+requests==2.31.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 rfc3339-validator==0.1.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-rsa==4.9; python_version >= "3.6" and python_version < "4" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"))
+rpds-py==0.10.0; python_version >= "3.8"
+rsa==4.9; python_version >= "3.6" and python_version < "4" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
 rx==1.6.3; python_version >= "3.9" and python_version < "3.10"
-six==1.16.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-slack-sdk==3.20.2; python_full_version >= "3.6.0"
+six==1.16.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
+slack-sdk==3.21.3; python_full_version >= "3.6.0"
 slackclient==2.9.4; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-soupsieve==2.4; python_full_version >= "3.6.0" and python_version >= "3.7"
-sqlalchemy==1.4.46; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
+soupsieve==2.4.1; python_full_version >= "3.6.0" and python_version >= "3.7"
+sqlalchemy==1.4.49; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 strict-rfc3339==0.7; python_version >= "3.6"
 tabulate==0.9.0; python_version >= "3.9" and python_version < "3.10"
-testpath==0.6.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
 toposort==1.10; python_version >= "3.9" and python_version < "3.10"
-tqdm==4.65.0; python_version >= "3.9" and python_version < "3.10"
-traitlets==5.9.0; python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.8"
+tqdm==4.66.1; python_version >= "3.9" and python_version < "3.10"
 typing-compat==0.1.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
 typing-extensions==3.10.0.2
+tzdata==2023.3; python_version >= "3.9"
 uritemplate==3.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-urllib3==1.26.15; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7") or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-watchdog==2.3.1; python_version >= "3.9" and python_version < "3.10"
-webencodings==0.5.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-websocket-client==1.5.1; python_version >= "3.7"
-werkzeug==1.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-yarl==1.8.2; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-zope.event==4.6; python_version >= "2.7" and python_full_version < "3.0.0" or python_version > "3.5" and python_full_version < "3.0.0" or python_version > "3.5"
-zope.interface==6.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_version >= "3.7"
+urllib3==2.0.4; python_version >= "3.9" and python_version < "3.10"
+watchdog==3.0.0; python_version >= "3.9" and python_version < "3.10"
+websocket-client==1.6.2; python_version >= "3.8"
+yarl==1.9.2; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"

--- a/orchestration/requirements.txt
+++ b/orchestration/requirements.txt
@@ -20,7 +20,7 @@ dagster-pandas==0.12.14
 dagster-postgres==0.12.14
 dagster-slack==0.12.14
 dagster==0.12.14
-data-repo-client==1.518.0
+data-repo-client==1.521.0
 docstring-parser==0.15; python_version >= "3.9" and python_version < "3.10"
 frozenlist==1.4.0; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 google-api-core==2.11.1; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
@@ -31,7 +31,7 @@ google-cloud-bigquery==2.34.3; python_version >= "3.6" and python_version < "3.1
 google-cloud-core==2.3.3; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
 google-cloud-storage==1.44.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 google-crc32c==1.5.0; python_version >= "3.9" and python_version < "3.10"
-google-resumable-media==2.5.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
+google-resumable-media==2.6.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
 google==3.0.0; python_version >= "3.6"
 googleapis-common-protos==1.60.0; python_version >= "3.9" and python_version < "3.10"
 graphql-core==2.3.2
@@ -69,7 +69,7 @@ pyparsing==3.1.1; python_full_version >= "3.6.8" and python_version > "3.0"
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.8" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0")
 python-dateutil==2.8.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 python-editor==1.0.4; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-pytz==2023.3; python_version >= "3.9" and python_version < "3.10"
+pytz==2023.3.post1; python_version >= "3.9" and python_version < "3.10"
 pytzdata==2020.1; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
 pywin32==306; python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows"
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
@@ -77,13 +77,13 @@ referencing==0.30.2; python_version >= "3.8"
 requests-oauthlib==1.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 requests==2.31.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 rfc3339-validator==0.1.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-rpds-py==0.10.0; python_version >= "3.8"
+rpds-py==0.10.2; python_version >= "3.8"
 rsa==4.9; python_version >= "3.6" and python_version < "4" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10")
 rx==1.6.3; python_version >= "3.9" and python_version < "3.10"
 six==1.16.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 slack-sdk==3.21.3; python_full_version >= "3.6.0"
 slackclient==2.9.4; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-soupsieve==2.4.1; python_full_version >= "3.6.0" and python_version >= "3.7"
+soupsieve==2.5; python_full_version >= "3.6.0" and python_version >= "3.8"
 sqlalchemy==1.4.49; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 strict-rfc3339==0.7; python_version >= "3.6"
 tabulate==0.9.0; python_version >= "3.9" and python_version < "3.10"


### PR DESCRIPTION
## Why

[FE-45](https://broadworkbench.atlassian.net/browse/FE-45)

## This PR
Adding an Action to recreate requirements.txt on PR to main to keep req.txt up to date for Sourceclear. 
Reminder - we do not use requirements.txt to install dependencies - see the main README for details.

## Checklist
- [x] Documentation has been updated as needed.


[FE-45]: https://broadworkbench.atlassian.net/browse/FE-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ