### PR TITLE
DI-285 typo in partition setup and change multiple matches fail to warn

### DIFF
--- a/orchestration/hca_manage/manifest.py
+++ b/orchestration/hca_manage/manifest.py
@@ -181,7 +181,7 @@ def load(args: argparse.Namespace) -> None:
         args.env,
         args.csv_path,
         args.release_tag,
-        f"cut_project_snapshot_{ENV_PIPELINE_ENDINGS[args.env]}",
+        f"cut_project_snapshot_job_{ENV_PIPELINE_ENDINGS[args.env]}",
         project_id_only=True,
         include_release_tag=True
     )

--- a/orchestration/hca_orchestration/solids/create_snapshot.py
+++ b/orchestration/hca_orchestration/solids/create_snapshot.py
@@ -117,7 +117,7 @@ def get_snapshot_from_project(context: AbstractComputeExecutionContext) -> Any:
             [release_tag={release_tag}].")
     response = context.resources.data_repo_client.enumerate_snapshots(filter=dataset_name)
     if len(response.items) != 1:
-        raise Failure("There is more than one snapshot matching this dataset_name")
+        logging.warning("There is more than one snapshot matching this dataset_name")
     snapshot_id = response.items[0].id
     return snapshot_id
 


### PR DESCRIPTION
## Why

[DI-285](https://broadworkbench.atlassian.net/browse/DI-285)

## This PR
Fixes a typo in manifest.py that was setting up Dagster partitions for an incorrectly named bucket.
Changes a failure to a warning on detecting multiple matches for the dataset names in the make_public step. It's fine for there to be more than 1 snapshot per dataset name


## Checklist
- [x] Documentation has been updated as needed.
