### PR TITLE
FE-92 fix git action to use real poetry lock

### DIFF
--- a/.github/workflows/generate-requirements-file.yaml
+++ b/.github/workflows/generate-requirements-file.yaml
@@ -1,8 +1,11 @@
+# generates a requirements.txt file from poetry.lock and commits it to the branch that triggered the workflow,
+# for SourceClear to use to scan for vulnerabilities.
 name: Generate requirements file
 
 on:
   pull_request:
-    branches: [master, main]
+    branches:
+      - main
 
 jobs:
   generate-requirements-file:
@@ -22,12 +25,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-
-      #This is important since a lock file is required for the next step
-      - name: Generate a lock file
-        run: poetry lock --no-interaction
-        working-directory: ${{ github.workspace }}/orchestration
-
 
       - name: Generate requirements.txt
         run: poetry export -f requirements.txt --without-hashes --no-interaction --output requirements.txt

--- a/.github/workflows/super_linter.yaml
+++ b/.github/workflows/super_linter.yaml
@@ -18,8 +18,6 @@ on:
   push:
     branches-ignore: [master, main]
     # Remove the line above to run when pushing to main
-  pull_request:
-    branches: [master, main]
 
 ###############
 # Set the Job #


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadworkbench.atlassian.net/browse/FE-92)

## This PR

- Updates the current generate requirements.txt git action so it no longer creates a poetry.lock file. Instead, it uses the lock file already committed to the repository and used in the user code image. This ensures that the requirements.txt is both up to date and matches what is in production.

- Fixed the linter git action so that it only runs on pushes to branches that aren't main

## Checklist
- [X] Documentation has been updated as needed.
