### PR TITLE
FE-92 fix git action to use real poetry lock

### DIFF
--- a/.github/workflows/generate-requirements-file.yaml
+++ b/.github/workflows/generate-requirements-file.yaml
@@ -1,8 +1,11 @@
+# generates a requirements.txt file from poetry.lock and commits it to the branch that triggered the workflow,
+# for SourceClear to use to scan for vulnerabilities.
 name: Generate requirements file
 
 on:
   pull_request:
-    branches: [master, main]
+    branches:
+      - main
 
 jobs:
   generate-requirements-file:
@@ -12,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9.16
       - name: Install Poetry
@@ -22,12 +25,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-
-      #This is important since a lock file is required for the next step
-      - name: Generate a lock file
-        run: poetry lock --no-interaction
-        working-directory: ${{ github.workspace }}/orchestration
-
 
       - name: Generate requirements.txt
         run: poetry export -f requirements.txt --without-hashes --no-interaction --output requirements.txt

--- a/.github/workflows/super_linter.yaml
+++ b/.github/workflows/super_linter.yaml
@@ -18,8 +18,6 @@ on:
   push:
     branches-ignore: [master, main]
     # Remove the line above to run when pushing to main
-  pull_request:
-    branches: [master, main]
 
 ###############
 # Set the Job #


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadworkbench.atlassian.net/browse/FE-92)

## This PR

- updated the Regenerate requirements.txt git action to no longer generate its own poetry.lock. Instead it uses the lock file in the repository which is the same lock file in the user code Docker image.
- updated the linter to run on push to all branches but main
- updated the regen requirements.txt git action to use the setup-python@v4 action due to the end of life of node 12

## Checklist
- [x] Documentation has been updated as needed.
