### PR TITLE
FE-181 remove psp from hca-ingest helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ system design information.
 All code should first be developed on a branch off of the `main` branch. Once ready for review, \
 submit a PR against `main` and tag the `broad-data-ingest-admin` team for review, and ensure all checks are passing.
 
-The Docker image at the top of the repository here should be updated when you are done developing. To do so, you will need to build & push it to Artifact Registry, \
-using `update_docker_image.sh`. First update the version field, then run the script. \
+The Docker image at the top of the repository will be auto built & pushed to Artifact Registry \
+each time you push to dev or merge to main. \
+See ./github/workflows/build_and_publish_dev.yaml and ./github/workflows/build_and_publish_main.yaml
+To build manually, use `update_docker_image.sh`. First update the version field, then run the script. \
 This will build the image, tag it with the version, and push the image to Artifact Registry. \
 Note that this may take a bit to establish the connection to Artifact Registry, so be patient. \
 _It may be that you are on the split VPN and/or trying to push over IPv6. Either turn off the VPN or turn off IPV6 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   app:
     # for dev
     # build: .
+    # or specify your dev sha or local image
     image: us-east4-docker.pkg.dev/broad-dsp-monster-hca-dev/monster-dev-env/hca_ingest_compose_dev_env:latest
     container_name: hca_dev_env
     command: bin/bash -p 8080:80 --reload

--- a/ops/helmfiles/dagster/helmfile.yaml
+++ b/ops/helmfiles/dagster/helmfile.yaml
@@ -7,15 +7,6 @@ repositories:
 
 # helm releases to be deployed
 releases:
-  # sets up a pod security policy for the given service account
-  # (required by our org's broader security policy)
-  - name: monster-psp    # release name
-    namespace: dagster   # target namespace
-    chart: datarepo-helm/serviceaccount-psp   # chart name
-    missingFileHandler: Warn
-    values:
-      - serviceAccount:
-          name: monster-dagster
   - name: monster-secrets
     namespace: dagster
     chart: datarepo-helm/create-secret-manager-secret

--- a/update_docker_image.sh
+++ b/update_docker_image.sh
@@ -2,6 +2,8 @@
 set -e
 
 # DEVELOPER: update this field anytime you make a new docker image
+# Note that this image will be auto built each time you push to dev or merge to main
+# see ./github/workflows/build_and_publish_dev.yaml and ./github/workflows/build_and_publish_main.yaml
 VERSION="0.5"
 BUILD_TAG="us-east4-docker.pkg.dev/broad-dsp-monster-hca-dev/monster-dev-env/hca_ingest_compose_dev_env:${VERSION}"
 

--- a/update_docker_image.sh
+++ b/update_docker_image.sh
@@ -2,7 +2,7 @@
 set -e
 
 # DEVELOPER: update this field anytime you make a new docker image
-VERSION="0.4"
+VERSION="0.5"
 BUILD_TAG="us-east4-docker.pkg.dev/broad-dsp-monster-hca-dev/monster-dev-env/hca_ingest_compose_dev_env:${VERSION}"
 
 echo "using build tag: ${BUILD_TAG}"


### PR DESCRIPTION
## Why

[FE-181](https://broadworkbench.atlassian.net/browse/FE-181)

## This PR
Removes PodSecurityPolicies from the hca-ingest helm chart, due to the fact that our clusters are on the release channel and were auto updated to GKEv1.25 from which Pod SecurityPolicies have been removed.

Related to https://github.com/broadinstitute/datarepo-helm/pull/257

## Checklist
- [X] Documentation has been updated as needed.
