### PR TITLE
FE-231 upgrade aiohttp to 3.9.4

### DIFF
--- a/.github/workflows/validate_pull_request_main.yaml
+++ b/.github/workflows/validate_pull_request_main.yaml
@@ -51,6 +51,9 @@ jobs:
         run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
       - name: Publish Scala Test coverage
         uses: codecov/codecov-action@v1
-      - name: Run E2E test suite
-        run: poetry run pytest -v -m e2e
-        working-directory: ${{ github.workspace }}/orchestration
+# We are skipping the E2E tests during PR validation until we refactor to test against TDR prod
+# See FE-203 and FE-204 for complete details
+# See the e2e README for instructions to run the tests locally (orchestration/hca_orchestration/tests/e2e/README.md)
+#      - name: Run E2E test suite
+#        run: poetry run pytest -v -m e2e
+#        working-directory: ${{ github.workspace }}/orchestration

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ system design information.
       the docker compose command, as this will pull the latest image from Artifact Registry._
 * Authenticate with gcloud using your Broad credentials `gcloud auth login`
 * Then set up your billing project `gcloud config set project PROJECT_ID`
+  * For prod this is `mystical-slate-284720`
 * Then set up your default login for applications `gcloud auth application-default login`
 * Build and run the dataflow tests
   * From the repository/image root: `sbt test` 

--- a/orchestration/hca_manage/manifest.py
+++ b/orchestration/hca_manage/manifest.py
@@ -109,7 +109,7 @@ def _parse_csv(csv_path: str, env: str, project_id_only: bool = False,
                 project_id = row[1]
                 key = project_id
             else:
-
+                # TODO check for all caps - change to all caps if not, then match
                 if institution not in STAGING_AREA_BUCKETS[env]:
                     raise Exception(f"Unknown institution {institution} found")
 

--- a/orchestration/hca_orchestration/tests/e2e/README.md
+++ b/orchestration/hca_orchestration/tests/e2e/README.md
@@ -5,7 +5,9 @@ They run against a real dataset, using a local beam runner and staged fixture da
 GCS. They are excluded from the default unit test suite given how long they take to run,
 but are run as part of CI (and are completely runnable locally).
 
-Note that test_load_hca.py is currently being skipped - see FE-203 for more details.
+Note that these currently being skipped in CI (validate_pull_request_main.yaml)\
+and will be re-enabled when either there is time to refactor to use TDR prod or we've migrated (and will use TDR prod)\
+See FE-203 & FE-204 for more details.
 
 ### To run locally:
 

--- a/orchestration/hca_orchestration/tests/e2e/test_load_hca.py
+++ b/orchestration/hca_orchestration/tests/e2e/test_load_hca.py
@@ -9,10 +9,7 @@ from hca_orchestration.tests.support.bigquery import (
     assert_metadata_loaded,
 )
 
-logging.info("Skipping test_load_hca.py - FE-203")
 
-
-@pytest.mark.skip(reason="This test is failing against TDR/BQ dev env - FE-203")
 @pytest.mark.e2e
 def test_load_hca(load_hca_run_config, dataset_name, tdr_bigquery_client, dataset_info):
     job = load_hca_job()

--- a/orchestration/poetry.lock
+++ b/orchestration/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aiohttp"
-version = "3.9.2"
+version = "3.9.4"
 description = "Async http client/server framework (asyncio)"
 category = "main"
 optional = false
@@ -597,7 +597,7 @@ beautifulsoup4 = "*"
 
 [[package]]
 name = "google-api-core"
-version = "2.17.1"
+version = "2.19.0"
 description = "Google API client core library"
 category = "main"
 optional = false
@@ -608,6 +608,7 @@ google-auth = ">=2.14.1,<3.0.dev0"
 googleapis-common-protos = ">=1.56.2,<2.0.dev0"
 grpcio = {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""}
 grpcio-status = {version = ">=1.33.2,<2.0.dev0", optional = true, markers = "extra == \"grpc\""}
+proto-plus = ">=1.22.3,<2.0.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
 requests = ">=2.18.0,<3.0.0.dev0"
 
@@ -2056,7 +2057,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.16"
-content-hash = "3843b5b4da4115630ff2d7fa35ec0a3b1c2ca2c3d9fa0860b81359eff735853b"
+content-hash = "dbf5023620b480de6dff2e10f540a88e64e4f72cad01fbf79fce8bcddd47c6f8"
 
 [metadata.files]
 aiohttp = []

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -35,7 +35,7 @@ sentry-sdk = "^1.39.2"
 typing-extensions = "^3.7.4"
 # werkzeug = "2.2.3"
 # will have to update dagit which means updating broad-dagster-utils - FE-36
-aiohttp = "3.9.2"
+aiohttp = "3.9.4"
 
 [tool.poetry.dev-dependencies]
 # NB this notation is not preferred after poetry 1.2.0 https://python-poetry.org/docs/master/managing-dependencies/

--- a/orchestration/requirements.txt
+++ b/orchestration/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.2; python_version >= "3.8"
+aiohttp==3.9.4; python_version >= "3.8"
 aiosignal==1.3.1; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 alembic==1.6.5; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
 argo-workflows==5.0.0
@@ -23,7 +23,7 @@ dagster==0.12.14
 data-repo-client==1.542.0
 docstring-parser==0.15; python_version >= "3.9" and python_version < "3.10"
 frozenlist==1.4.0; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.6.0"
-google-api-core==2.17.1; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+google-api-core==2.19.0; python_version >= "3.9" and python_version < "3.10" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 google-api-python-client==1.12.11; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth-httplib2==0.1.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth==2.23.3; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10"


### PR DESCRIPTION
## Why

[FE-231](https://broadworkbench.atlassian.net/browse/FE-231)

The library aiohttp has a high severity vulnerability that could lead to denial of service attacks against the service. This vulnerability has been fixed in version 3.9.4.

The version found in import service is 3.9.2.

## This PR
Sets the aiohttp version to 3.9.4.
[Pytests were run locally](https://broadworkbench.atlassian.net/browse/FE-231), and are [run when this PR is opened to merge to main](https://github.com/DataBiosphere/hca-ingest/blob/main/.github/workflows/validate_pull_request_main.yaml).
_[note that the e2e tests are currently disabled](https://github.com/DataBiosphere/hca-ingest/blob/main/orchestration/hca_orchestration/tests/e2e/README.md)_
The updated image was deployed to dev and the validation pipeline was run to prove that this did not break our ability to reach the Dagster repository.
Smoke tests will also be run on prod after deploy, if they fail, the last known good image will be deployed.

## Checklist
- [x] Documentation has been updated as needed.


[FE-231]: https://broadworkbench.atlassian.net/browse/FE-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ