### PR TITLE
FE-232 fix dev env for manifest dot py

### DIFF
--- a/orchestration/poetry.lock
+++ b/orchestration/poetry.lock
@@ -168,7 +168,7 @@ python-versions = ">=3.6"
 name = "cffi"
 version = "1.16.0"
 description = "Foreign Function Interface for Python calling C code."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 
@@ -1456,7 +1456,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -2057,7 +2057,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.16"
-content-hash = "dbf5023620b480de6dff2e10f540a88e64e4f72cad01fbf79fce8bcddd47c6f8"
+content-hash = "188d2c1e4fa7c8d434aa39e0854b49e1ff4a606096161d60ac1ecc9b43b04e95"
 
 [metadata.files]
 aiohttp = []

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -10,6 +10,7 @@ python = "3.9.16"
 argo-workflows = "^5.0.0"
 broad-dagster-utils = "0.6.7"
 cached-property = "^1.5.2"
+cffi = "1.16.0"
 # TODO: we'll probably want to use just the dagster version here and not the API versions as well
 # https://github.com/dagster-io/dagster/blob/master/MIGRATION.md#migrating-to-10
 dagster = "0.12.14"

--- a/orchestration/requirements.txt
+++ b/orchestration/requirements.txt
@@ -9,6 +9,7 @@ broad-dagster-utils==0.6.7; python_version >= "3.9" and python_version < "3.10"
 cached-property==1.5.2
 cachetools==5.3.2; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10"
 certifi==2023.7.22; python_version >= "3.9" and python_version < "3.10"
+cffi==1.16.0; python_version >= "3.8"
 charset-normalizer==3.3.1; python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.7.0"
 click==7.1.2; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0"
 colorama==0.4.6; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" and platform_system == "Windows" or python_version >= "3.9" and python_version < "3.10" and platform_system == "Windows" and python_full_version >= "3.7.0"
@@ -65,6 +66,7 @@ psutil==5.9.6; python_version >= "3.9" and python_full_version < "3.0.0" and pyt
 psycopg2-binary==2.9.9; python_version >= "3.7"
 pyasn1-modules==0.3.0; python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_full_version >= "3.6.0" and python_version >= "3.9" and python_version < "3.10"
 pyasn1==0.5.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.6.0"
+pycparser==2.21; python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.8"
 pyparsing==3.1.1; python_full_version >= "3.6.8" and python_version > "3.0"
 pyreadline3==3.4.1; sys_platform == "win32" and python_version >= "3.8" and (python_version >= "3.9" and python_full_version < "3.0.0" and python_version < "3.10" or python_version >= "3.9" and python_version < "3.10" and python_full_version >= "3.5.0")
 python-dateutil==2.8.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")


### PR DESCRIPTION
[FE-232](https://broadworkbench.atlassian.net/browse/FE-232)

## Problem:
The [first step in the HCA ingest process](https://docs.google.com/document/d/1NQCDlvLgmkkveD4twX5KGv6SZUl8yaIBgz_l1EcrHdA/edit#heading=h.cg8d8o5kklql) requires the creation and deployment of a manifest of the data to be ingested. This is accomplished via a python script - manifest.py - which has a number of dependencies. To expedite the setup of a dev env for this script and any HCA ingest work, I had created a Docker Compose dev env. The latest version of the image had a known poetry issue whereby not using a virtualenv (as is suggested for Poetry in Docker) ran into an instance of Poetry removing a previously installed library (cffi) which was a dependency of several other required libraries and dependencies used by manifest.py. As such, attempting to run manifest.py in the Docker Compose dev env failed - and the work around of setting up a local dev takes 10-12 hours - which is prohibitive, to say the least.

## Solution:
Added cffi to the pyproject.toml, so that it is required and cannot be removed.

## To Test:
* clone this repository and check out the branch for this PR `FE-232-fix-dev-env-for-manifest-dot-py`
* from the root of the project invoke the Docker Compose dev env `docker compose run -w /hca-ingest app bash`
  * _Note that if you are not already logged in to gcloud, you will need to do so before running \
      the docker compose command, as this will pull the latest image from Artifact Registry._
* Authenticate with gcloud using your Broad credentials `gcloud auth login`
* Then set up your billing project `gcloud config set project PROJECT_ID`
* Then set up your default login for applications `gcloud auth application-default login`
* From `orchestration/`:
    * Run `poetry install` to set up a local python virtual environment and install needed dependencies
* From the root of the project, run the port forwarding script in the background `./ops/helmfiles/dagster/forward_ports.sh dev &` 
* Download the manifest file attached to this PR and put it in the orchestration directory for this project.
    * [dcp99_manifest.csv](https://github.com/user-attachments/files/15902983/dcp99_manifest.csv)
* From `orchestration/` run 'poetry run python3 hca_manage/manifest.py load -e dev -c dcp99_manifest.csv -r dcp99`

The script should complete without error.

More context in the [Ops Playbook](https://docs.google.com/document/d/1NQCDlvLgmkkveD4twX5KGv6SZUl8yaIBgz_l1EcrHdA/edit#heading=h.cg8d8o5kklql) and the [top level README](https://github.com/DataBiosphere/hca-ingest/blob/main/README.md) and [Ops README](https://github.com/DataBiosphere/hca-ingest/blob/main/ops/helmfiles/README.md) in this project.

## Checklist
- [x] Documentation has been updated as needed.

[FE-232]: https://broadworkbench.atlassian.net/browse/FE-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ