### PR TITLE
FE-370 update hca_manage/check to output row_id(s)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     # or specify your dev sha or local image
     image: us-east4-docker.pkg.dev/broad-dsp-monster-hca-dev/monster-dev-env/hca_ingest_compose_dev_env:latest
     container_name: hca_dev_env
+    working_dir: /hca-ingest
     command: bin/bash -p 8080:80 --reload
     ports:
       - 8080:80

--- a/orchestration/hca_manage/README.md
+++ b/orchestration/hca_manage/README.md
@@ -17,12 +17,19 @@ Checks the integrity of an HCA dataset or snapshot, looking for null file refere
 links -> project references.
 
 Example run:
-`poetry run check -e dev -d hca_dev_20201203`
+`poetry run check -e dev -i 8cb49ef6-63db-4f56-b9a8-d33278d93z0f`
 
 To actually remove things, add the remove `-r` flag after:
-`poetry run check -e dev -d hca_dev_20201203 -r`
+`poetry run check -e dev -i 8cb49ef6-63db-4f56-b9a8-d33278d93z0f -r`
 
 Be very sure and careful when adding the remove flag.
+
+_Notes_: 
+- You may need to first add your user to the dataset as a steward - 
+being in monster@firecloud may not propagate your permissions.
+- If you run with -r you may get an error from TDR about your bucket permissions -
+follow the error message and add the indicated accounts to the bucket (likely your user, the ingest account, 
+and your proxy group). **Be sure to remove these users from the bucket and the dataset after you are done.**
 
 ### Snapshot
 

--- a/orchestration/hca_manage/bq_managers.py
+++ b/orchestration/hca_manage/bq_managers.py
@@ -61,6 +61,7 @@ class BQRowManager(_BQRowDataclass, ABC):
             rids_to_process = get_rids(table_name)
             if len(rids_to_process) > 0:
                 logging.info(f"{table_name} has {len(rids_to_process)} failing rows due to {issue}")
+                logging.info(f"Rows: {rids_to_process}")
                 if soft_delete:
                     local_filename = f"{os.getcwd()}/{table_name}.csv"
                     try:


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadworkbench.atlassian.net/jira/software/c/projects/FE/boards/200?selectedIssue=FE-370)

While debugging in FE-370 I found that it would be helpful for the check tool to output the row_id(s) of any offending rows found during the check. (and the example had incorrect syntax)

There were also a number of permissions paradigms that shifted since this tool was created, and have been noted in the README.

## This PR

## Checklist
- [x] Documentation has been updated as needed.
